### PR TITLE
refactor(cuentas): use direct billing endpoint GET /accounts/{accountId}/billings/{id}

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   check-linked-issue:
+    name: Check Linked Issue
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -23,4 +23,8 @@ class ApiConfig {
   /// Build URL para companies con pagination
   static String companiesUrl({int page = 1, int pageSize = 20}) =>
       '$baseUrl$companiesPath?page=$page&page_size=$pageSize';
+
+  /// Direct billing endpoint: GET /accounts/{accountId}/billings/{billingId}
+  static String accountBillingUrl(String accountId, String billingId) =>
+      '$baseUrl/accounts/$accountId/billings/$billingId';
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -58,7 +58,8 @@ class AppRouter {
             builder: (context, state) {
               final id = state.pathParameters['id']!;
               final periodo = state.uri.queryParameters['periodo'] ?? _currentPeriodo();
-              return CuentaDetallePage(cuentaId: id, periodo: periodo);
+              final accountId = state.uri.queryParameters['accountId'] ?? '';
+              return CuentaDetallePage(cuentaId: id, accountId: accountId, periodo: periodo);
             },
           ),
 

--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -56,16 +56,17 @@ class CuentaDatasource {
     return items.map((json) => _fromJson(json)).toList();
   }
 
-  /// GET /periods/{period}/billings — filtra por id
-  Future<Cuenta> getDetalle(String id, String periodo) async {
-    _validarPeriodo(periodo);
-    _sanitizarId(id);
+  /// GET /accounts/{accountId}/billings/{billingId} — direct endpoint
+  Future<Cuenta> getDetalle(String accountId, String cuentaId) async {
+    _sanitizarId(accountId);
+    _sanitizarId(cuentaId);
 
-    final cuentas = await getCuentasPorPeriodo(periodo);
-    return cuentas.firstWhere(
-      (c) => c.id == id,
-      orElse: () => throw StateError('No se encontró la cuenta con id: $id'),
+    final response = await _dio.get(
+      ApiConfig.accountBillingUrl(accountId, cuentaId),
     );
+    final data = response.data;
+    final billing = data['billing'] ?? data['data'] ?? data;
+    return _fromJson(billing);
   }
 
   /// PUT /accounts/{accountID}/billings/{id}

--- a/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
+++ b/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
@@ -14,8 +14,8 @@ class CuentaRepositoryImpl implements CuentaRepository {
   }
 
   @override
-  Future<Cuenta> getDetalleCuenta(String id, String periodo) {
-    return _datasource.getDetalle(id, periodo);
+  Future<Cuenta> getDetalleCuenta(String accountId, String cuentaId) {
+    return _datasource.getDetalle(accountId, cuentaId);
   }
 
   @override

--- a/lib/features/cuentas/domain/repositories/cuenta_repository.dart
+++ b/lib/features/cuentas/domain/repositories/cuenta_repository.dart
@@ -5,7 +5,7 @@ abstract class CuentaRepository {
   /// Get list of accounts for a specific period (yyyymm format)
   Future<List<Cuenta>> getCuentasPorPeriodo(String periodo);
 
-  Future<Cuenta> getDetalleCuenta(String id, String periodo);
+  Future<Cuenta> getDetalleCuenta(String accountId, String cuentaId);
 
   Future<bool> registrarPago(
     String cuentaId,

--- a/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
+++ b/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
@@ -20,10 +20,11 @@ class CuentasLoadRequested extends CuentasEvent {
 
 class CuentaDetalleRequested extends CuentasEvent {
   final String cuentaId;
+  final String accountId;
   final String periodo;
-  const CuentaDetalleRequested(this.cuentaId, this.periodo);
+  const CuentaDetalleRequested(this.cuentaId, this.accountId, this.periodo);
   @override
-  List<Object?> get props => [cuentaId, periodo];
+  List<Object?> get props => [cuentaId, accountId, periodo];
 }
 
 class PagoRegistrado extends CuentasEvent {
@@ -117,14 +118,30 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
   ) async {
     emit(CuentasLoading());
     try {
+      final accountId = _deriveAccountId(event.cuentaId) ?? event.accountId;
       final cuenta = await _repository.getDetalleCuenta(
+        accountId,
         event.cuentaId,
-        event.periodo,
       );
       emit(CuentaDetalleLoaded(cuenta));
     } catch (e) {
       emit(CuentasError(e.toString()));
     }
+  }
+
+  String? _deriveAccountId(String cuentaId) {
+    final currentState = state;
+    if (currentState is CuentasLoaded) {
+      try {
+        final cuenta = currentState.cuentas.firstWhere(
+          (c) => c.id == cuentaId,
+        );
+        return cuenta.accountId;
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
   }
 
   Future<void> _onPagoRegistrado(

--- a/lib/features/cuentas/presentation/pages/cuenta_detalle_page.dart
+++ b/lib/features/cuentas/presentation/pages/cuenta_detalle_page.dart
@@ -11,11 +11,13 @@ import '../widgets/estado_badge.dart';
 /// Detalle de un billing
 class CuentaDetallePage extends StatefulWidget {
   final String cuentaId;
+  final String accountId;
   final String periodo;
 
   const CuentaDetallePage({
     super.key,
     required this.cuentaId,
+    required this.accountId,
     required this.periodo,
   });
 
@@ -31,7 +33,7 @@ class _CuentaDetallePageState extends State<CuentaDetallePage> {
   void initState() {
     super.initState();
     context.read<CuentasBloc>().add(
-      CuentaDetalleRequested(widget.cuentaId, widget.periodo),
+      CuentaDetalleRequested(widget.cuentaId, widget.accountId, widget.periodo),
     );
   }
 

--- a/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
+++ b/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
@@ -511,7 +511,7 @@ child: Column(
         color: Colors.transparent,
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
-          onTap: () => context.push('/cuentas/detalle/${cuenta.id}?periodo=$_currentPeriodo'),
+          onTap: () => context.push('/cuentas/detalle/${cuenta.id}?accountId=${cuenta.accountId}&periodo=$_currentPeriodo'),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Row(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env
+    - .env.example

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env.example
+    - .env

--- a/test/features/cuentas/cuentas_bloc_test.dart
+++ b/test/features/cuentas/cuentas_bloc_test.dart
@@ -63,6 +63,39 @@ void main() {
     );
 
     blocTest<CuentasBloc, CuentasState>(
+      'emits [CuentasLoading, CuentaDetalleLoaded] when CuentaDetalleRequested succeeds',
+      setUp: () {
+        when(() => mockRepository.getDetalleCuenta(any(), any()))
+            .thenAnswer((_) async => testCuenta);
+      },
+      build: () => CuentasBloc(mockRepository),
+      seed: () => CuentasLoaded([testCuenta], '202604'),
+      act: (bloc) => bloc.add(const CuentaDetalleRequested('1', 'acc-1', '202604')),
+      expect: () => [
+        isA<CuentasLoading>(),
+        isA<CuentaDetalleLoaded>(),
+      ],
+      verify: (_) {
+        verify(() => mockRepository.getDetalleCuenta('acc-1', '1')).called(1);
+      },
+    );
+
+    blocTest<CuentasBloc, CuentasState>(
+      'emits [CuentasLoading, CuentasError] when CuentaDetalleRequested fails',
+      setUp: () {
+        when(() => mockRepository.getDetalleCuenta(any(), any()))
+            .thenThrow(Exception('Not found'));
+      },
+      build: () => CuentasBloc(mockRepository),
+      seed: () => CuentasLoaded([testCuenta], '202604'),
+      act: (bloc) => bloc.add(const CuentaDetalleRequested('1', 'acc-1', '202604')),
+      expect: () => [
+        isA<CuentasLoading>(),
+        isA<CuentasError>(),
+      ],
+    );
+
+    blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, PagoSuccess] when PagoRegistrado succeeds',
       setUp: () {
         when(() => mockRepository.registrarPago(any(), any(), any(), any()))

--- a/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
@@ -136,21 +136,18 @@ void main() {
     });
 
     group('getDetalle', () {
-      test('returns Cuenta when found in period', () async {
-        // Datasource expects account_name, amount_billed, amount_paid fields
-        final cuentasJson = [
-          {
-            'id': 'cta_detail',
-            'account_id': 'acc_123',
-            'account_name': 'Netflix',
-            'amount_billed': 15000.0,
-            'amount_paid': 0.0,
-            'is_paid': false,
-            'status': 'pending',
-            'period': '202404',
-          },
-        ];
-        final responseData = ApiResponseBuilder.success(data: cuentasJson);
+      test('calls direct endpoint /accounts/{accountId}/billings/{billingId}', () async {
+        final cuentaJson = {
+          'id': 'cta_direct',
+          'account_id': 'acc_123',
+          'account_name': 'Direct Service',
+          'amount_billed': 15000.0,
+          'amount_paid': 0.0,
+          'is_paid': false,
+          'status': 'pending',
+          'period': '202404',
+        };
+        final responseData = {'billing': cuentaJson};
 
         when(() => mockDio.get(
           any(),
@@ -158,67 +155,42 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: ApiConfig.periodBillingsUrl('202404')),
+          requestOptions: RequestOptions(path: ApiConfig.accountBillingUrl('acc_123', 'cta_direct')),
           statusCode: 200,
           data: responseData,
         ));
 
-        final result = await datasource.getDetalle('cta_detail', '202404');
+        final result = await datasource.getDetalle('acc_123', 'cta_direct');
 
-        expect(result.id, equals('cta_detail'));
-        expect(result.nombre, equals('Netflix'));
+        expect(result.id, equals('cta_direct'));
+        expect(result.nombre, equals('Direct Service'));
       });
 
-      test('throws ArgumentError for invalid ID characters', () async {
+      test('throws ArgumentError for invalid accountId characters', () async {
         expect(
-          () => datasource.getDetalle('cta@invalid!', '202404'),
+          () => datasource.getDetalle('acc@invalid!', 'cta_001'),
           throwsA(isA<ArgumentError>()),
         );
       });
 
-      test('throws ArgumentError for empty ID', () async {
+      test('throws ArgumentError for invalid cuentaId characters', () async {
         expect(
-          () => datasource.getDetalle('', '202404'),
+          () => datasource.getDetalle('acc_123', 'cta@invalid!'),
           throwsA(isA<ArgumentError>()),
         );
       });
 
-      test('throws ArgumentError for invalid periodo', () async {
+      test('throws ArgumentError for empty accountId', () async {
         expect(
-          () => datasource.getDetalle('cta_001', '2024'),
+          () => datasource.getDetalle('', 'cta_001'),
           throwsA(isA<ArgumentError>()),
         );
       });
 
-      test('throws StateError when cuenta not found', () async {
-        final cuentasJson = [
-          {
-            'id': 'cta_existing',
-            'account_id': 'acc_123',
-            'account_name': 'Netflix',
-            'amount_billed': 15000.0,
-            'amount_paid': 0.0,
-            'is_paid': false,
-            'status': 'pending',
-            'period': '202404',
-          },
-        ];
-        final responseData = ApiResponseBuilder.success(data: cuentasJson);
-
-        when(() => mockDio.get(
-          any(),
-          queryParameters: any(named: 'queryParameters'),
-          options: any(named: 'options'),
-          cancelToken: any(named: 'cancelToken'),
-        )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: ApiConfig.periodBillingsUrl('202404')),
-          statusCode: 200,
-          data: responseData,
-        ));
-
+      test('throws ArgumentError for empty cuentaId', () async {
         expect(
-          () => datasource.getDetalle('cta_not_found', '202404'),
-          throwsA(isA<StateError>()),
+          () => datasource.getDetalle('acc_123', ''),
+          throwsA(isA<ArgumentError>()),
         );
       });
     });

--- a/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
+++ b/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
@@ -55,16 +55,16 @@ void main() {
     });
 
     group('getDetalleCuenta', () {
-      test('delegates to datasource with correct id and periodo', () async {
+      test('delegates to datasource with correct accountId and cuentaId', () async {
         final cuenta = CuentaFixture.createValidCuenta(id: 'cta_detail');
 
-        when(() => mockDatasource.getDetalle('cta_detail', '202404'))
+        when(() => mockDatasource.getDetalle('acc_123', 'cta_detail'))
             .thenAnswer((_) async => cuenta);
 
-        final result = await repository.getDetalleCuenta('cta_detail', '202404');
+        final result = await repository.getDetalleCuenta('acc_123', 'cta_detail');
 
         expect(result.id, equals('cta_detail'));
-        verify(() => mockDatasource.getDetalle('cta_detail', '202404')).called(1);
+        verify(() => mockDatasource.getDetalle('acc_123', 'cta_detail')).called(1);
       });
 
       test('forwards exceptions from datasource', () async {
@@ -72,7 +72,7 @@ void main() {
             .thenThrow(Exception('Not found'));
 
         expect(
-          () => repository.getDetalleCuenta('cta_invalid', '202404'),
+          () => repository.getDetalleCuenta('acc_123', 'cta_invalid'),
           throwsA(isA<Exception>()),
         );
       });


### PR DESCRIPTION
## Summary
- Refactor `getDetalle` to use direct billing endpoint `GET /accounts/{accountId}/billings/{id}`
- Previously fetched all accounts via `GET /periods/{period}/billings` then filtered in-memory with `firstWhere`
- Now makes single direct API call, eliminating unnecessary network transfer and in-memory filtering

## Changes
- **ApiConfig**: Added `accountBillingUrl(accountId, billingId)` method
- **DataSource**: Rewrote `getDetalle` to call direct endpoint
- **Repository**: Updated interface and implementation with `accountId` parameter
- **BLoC**: Added `accountId` to `CuentaDetalleRequested` event; derives from loaded list
- **Navigation**: Passes `accountId` as query param through router
- **Tests**: Updated all 3 test files for new signatures

## Test Plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 310 tests passing

## Linked Issue
Fixes #12