### PR TITLE
feat(cuentas): add reopen paid accounts functionality

### DIFF
--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -69,7 +69,7 @@ class CuentaDatasource {
     return _fromJson(billing);
   }
 
-  /// PUT /accounts/{accountID}/billings/{id}
+  /// PUT /accounts/{accountID}/billings/{id} — registra un pago
   Future<bool> registrarPago(
     String cuentaId,
     String accountId,
@@ -89,6 +89,29 @@ class CuentaDatasource {
     );
     final billing = response.data['billing'] ?? response.data;
     return billing['is_paid'] == true;
+  }
+
+  /// PUT /accounts/{accountID}/billings/{id} — reabre una cuenta pagada
+  /// Resetea amount_paid a 0 y is_paid a false para marcar como no pagada
+  Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal) async {
+    _sanitizarId(cuentaId);
+    _sanitizarId(accountId);
+
+    if (montoOriginal < 0) {
+      throw ArgumentError('El monto no puede ser negativo');
+    }
+
+    final response = await _dio.put(
+      '${ApiConfig.baseUrl}/accounts/$accountId/billings/$cuentaId',
+      data: {
+        'amount_billed': montoOriginal,
+        'amount_paid': 0,
+        'is_paid': false,
+      },
+    );
+    final billing = response.data['billing'] ?? response.data;
+    // Verificar que la cuenta quedó como no pagada
+    return billing['is_paid'] != true && (billing['amount_paid'] ?? 0) == 0;
   }
 
   Cuenta _fromJson(Map<String, dynamic> json) {

--- a/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
+++ b/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
@@ -32,4 +32,13 @@ class CuentaRepositoryImpl implements CuentaRepository {
       montoPagado,
     );
   }
+
+  @override
+  Future<bool> reopenAccount(
+    String cuentaId,
+    String accountId,
+    double montoOriginal,
+  ) {
+    return _datasource.reopenAccount(cuentaId, accountId, montoOriginal);
+  }
 }

--- a/lib/features/cuentas/domain/repositories/cuenta_repository.dart
+++ b/lib/features/cuentas/domain/repositories/cuenta_repository.dart
@@ -13,4 +13,10 @@ abstract class CuentaRepository {
     double montoTotal,
     double montoPagado,
   );
+
+  /// Reabre una cuenta pagada, reseteando el estado a no pagada
+  /// [cuentaId] - ID del billing
+  /// [accountId] - ID de la cuenta
+  /// [montoOriginal] - El monto facturado original (amount_billed) que se preserva
+  Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal);
 }

--- a/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
+++ b/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
@@ -42,6 +42,19 @@ class PagoRegistrado extends CuentasEvent {
   List<Object?> get props => [cuentaId, accountId, montoTotal, montoPagado];
 }
 
+class CuentaReopenRequested extends CuentasEvent {
+  final String cuentaId;
+  final String accountId;
+  final double montoOriginal;
+  const CuentaReopenRequested({
+    required this.cuentaId,
+    required this.accountId,
+    required this.montoOriginal,
+  });
+  @override
+  List<Object?> get props => [cuentaId, accountId, montoOriginal];
+}
+
 // States
 abstract class CuentasState extends Equatable {
   const CuentasState();
@@ -82,6 +95,20 @@ class PagoFailure extends CuentasState {
   List<Object?> get props => [message];
 }
 
+class ReopenSuccess extends CuentasState {
+  final String cuentaId;
+  const ReopenSuccess(this.cuentaId);
+  @override
+  List<Object?> get props => [cuentaId];
+}
+
+class ReopenFailure extends CuentasState {
+  final String message;
+  const ReopenFailure(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
 class CuentasError extends CuentasState {
   final String message;
   const CuentasError(this.message);
@@ -97,6 +124,7 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     on<CuentasLoadRequested>(_onLoadRequested);
     on<CuentaDetalleRequested>(_onDetalleRequested);
     on<PagoRegistrado>(_onPagoRegistrado);
+    on<CuentaReopenRequested>(_onReopenRequested);
   }
 
   Future<void> _onLoadRequested(
@@ -159,6 +187,23 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
       emit(PagoSuccess(event.cuentaId));
     } catch (e) {
       emit(PagoFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onReopenRequested(
+    CuentaReopenRequested event,
+    Emitter<CuentasState> emit,
+  ) async {
+    emit(CuentasLoading());
+    try {
+      await _repository.reopenAccount(
+        event.cuentaId,
+        event.accountId,
+        event.montoOriginal,
+      );
+      emit(ReopenSuccess(event.cuentaId));
+    } catch (e) {
+      emit(ReopenFailure(e.toString()));
     }
   }
 }

--- a/lib/features/cuentas/presentation/pages/cuenta_detalle_page.dart
+++ b/lib/features/cuentas/presentation/pages/cuenta_detalle_page.dart
@@ -85,6 +85,23 @@ class _CuentaDetallePageState extends State<CuentaDetallePage> {
                   backgroundColor: Colors.red,
                 ),
               );
+            } else if (state is ReopenSuccess) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Cuenta reabierta exitosamente'),
+                  backgroundColor: Colors.green,
+                ),
+              );
+              context.read<CuentasBloc>().add(
+                CuentaDetalleRequested(widget.cuentaId, widget.accountId, widget.periodo),
+              );
+            } else if (state is ReopenFailure) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(state.message),
+                  backgroundColor: Colors.red,
+                ),
+              );
             }
           },
           builder: (context, state) {
@@ -209,17 +226,36 @@ class _CuentaDetallePageState extends State<CuentaDetallePage> {
           ] else ...[
             Card(
               color: Colors.green.shade50,
-              child: const Padding(
-                padding: EdgeInsets.all(16),
-                child: Row(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
                   children: [
-                    Icon(Icons.check_circle, color: Colors.green),
-                    SizedBox(width: 12),
-                    Text(
-                      'Esta cuenta ya está pagada',
-                      style: TextStyle(
-                        color: Colors.green,
-                        fontWeight: FontWeight.bold,
+                    const Row(
+                      children: [
+                        Icon(Icons.check_circle, color: Colors.green),
+                        SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            'Esta cuenta ya está pagada',
+                            style: TextStyle(
+                              color: Colors.green,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    SizedBox(
+                      width: double.infinity,
+                      child: OutlinedButton.icon(
+                        onPressed: () => _showReopenConfirmation(context, cuenta),
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('Reabrir cuenta'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.orange.shade700,
+                          side: BorderSide(color: Colors.orange.shade700),
+                        ),
                       ),
                     ),
                   ],
@@ -298,5 +334,46 @@ class _CuentaDetallePageState extends State<CuentaDetallePage> {
       return Icons.phone_android;
     }
     return Icons.receipt_long;
+  }
+
+  Future<void> _showReopenConfirmation(BuildContext context, Cuenta cuenta) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reabrir cuenta'),
+        content: const Text(
+          '¿Estás seguro de que deseas reabrir esta cuenta pagada?\n\n'
+          'El monto pagado se eliminará y la cuenta volverá a estado pendiente.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.orange.shade700,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Reabrir'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      _handleReopen(context, cuenta);
+    }
+  }
+
+  void _handleReopen(BuildContext context, Cuenta cuenta) {
+    context.read<CuentasBloc>().add(
+      CuentaReopenRequested(
+        cuentaId: cuenta.id,
+        accountId: cuenta.accountId,
+        montoOriginal: cuenta.monto,
+      ),
+    );
   }
 }

--- a/test/features/cuentas/cuentas_bloc_test.dart
+++ b/test/features/cuentas/cuentas_bloc_test.dart
@@ -140,5 +140,48 @@ void main() {
         isA<PagoFailure>(),
       ],
     );
+
+    blocTest<CuentasBloc, CuentasState>(
+      'emits [CuentasLoading, ReopenSuccess] when CuentaReopenRequested succeeds',
+      setUp: () {
+        when(() => mockRepository.reopenAccount(any(), any(), any()))
+            .thenAnswer((_) async => true);
+      },
+      build: () => CuentasBloc(mockRepository),
+      act: (bloc) => bloc.add(const CuentaReopenRequested(
+        cuentaId: '1',
+        accountId: 'acc-1',
+        montoOriginal: 15000,
+      )),
+      expect: () => [
+        isA<CuentasLoading>(),
+        isA<ReopenSuccess>(),
+      ],
+      verify: (_) {
+        verify(() => mockRepository.reopenAccount(
+              '1',
+              'acc-1',
+              15000,
+            )).called(1);
+      },
+    );
+
+    blocTest<CuentasBloc, CuentasState>(
+      'emits [CuentasLoading, ReopenFailure] when CuentaReopenRequested fails',
+      setUp: () {
+        when(() => mockRepository.reopenAccount(any(), any(), any()))
+            .thenThrow(Exception('Reopen failed'));
+      },
+      build: () => CuentasBloc(mockRepository),
+      act: (bloc) => bloc.add(const CuentaReopenRequested(
+        cuentaId: '1',
+        accountId: 'acc-1',
+        montoOriginal: 15000,
+      )),
+      expect: () => [
+        isA<CuentasLoading>(),
+        isA<ReopenFailure>(),
+      ],
+    );
   });
 }

--- a/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
@@ -279,6 +279,114 @@ void main() {
       });
     });
 
+    group('reopenAccount', () {
+      test('returns true when account reopened successfully', () async {
+        final responseData = {
+          'billing': {'is_paid': false, 'amount_paid': 0},
+        };
+
+        when(() => mockDio.put(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          statusCode: 200,
+          data: responseData,
+        ));
+
+        final result = await datasource.reopenAccount(
+          'cta_001',
+          'acc_123',
+          15000.0,
+        );
+
+        expect(result, isTrue);
+      });
+
+      test('sends correct payload with amount_billed, amount_paid=0, is_paid=false', () async {
+        final responseData = {
+          'billing': {'is_paid': false, 'amount_paid': 0},
+        };
+
+        when(() => mockDio.put(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          statusCode: 200,
+          data: responseData,
+        ));
+
+        await datasource.reopenAccount('cta_001', 'acc_123', 15000.0);
+
+        verify(() => mockDio.put(
+          any(),
+          data: predicate<Map<String, dynamic>>((data) {
+            expect(data['amount_billed'], equals(15000.0));
+            expect(data['amount_paid'], equals(0));
+            expect(data['is_paid'], equals(false));
+            return true;
+          }),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).called(1);
+      });
+
+      test('returns false when API returns is_paid still true', () async {
+        final responseData = {
+          'billing': {'is_paid': true, 'amount_paid': 15000},
+        };
+
+        when(() => mockDio.put(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          statusCode: 200,
+          data: responseData,
+        ));
+
+        final result = await datasource.reopenAccount(
+          'cta_001',
+          'acc_123',
+          15000.0,
+        );
+
+        expect(result, isFalse);
+      });
+
+      test('throws ArgumentError for negative montoOriginal', () async {
+        expect(
+          () => datasource.reopenAccount('cta_001', 'acc_123', -100.0),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for empty cuentaId', () async {
+        expect(
+          () => datasource.reopenAccount('', 'acc_123', 15000.0),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for invalid cuentaId characters', () async {
+        expect(
+          () => datasource.reopenAccount('cta@invalid!', 'acc_123', 15000.0),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
     group('_fromJson', () {
       test('parses Cuenta correctly from API response', () async {
         final cuentaJson = {


### PR DESCRIPTION
## Summary
- Agrega funcionalidad para reabrir cuentas pagadas (issue #11)
- Nuevo método `reopenAccount` en datasource, repository y bloc
- Botón "Reabrir cuenta" en la UI con dialog de confirmación
- Payload PUT preserva `amount_billed`, resetea `amount_paid` a 0 y `is_paid` a false

## Files Changed
- `cuenta_datasource.dart` - nuevo método `reopenAccount`
- `cuenta_repository.dart` - nueva interface
- `cuenta_repository_impl.dart` - implementación
- `cuentas_bloc.dart` - nuevo evento y estados
- `cuenta_detalle_page.dart` - botón y dialog

## Test plan
- [x] Analyze pasa sin errores
- [ ] Probar en device/emulador cuando API esté lista

Closes #11