### PR TITLE
feat(cuentas): add individual account billing

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../features/admin/presentation/pages/categories_page.dart';
 import '../../features/auth/presentation/pages/login_page.dart';
+import '../../features/cuentas/presentation/pages/agregar_cuenta_page.dart';
 import '../../features/cuentas/presentation/pages/cuenta_detalle_page.dart';
 import '../../features/cuentas/presentation/pages/lista_cuentas_page.dart';
 import '../../features/empresas/presentation/pages/empresa_form_page.dart';
@@ -60,6 +61,16 @@ class AppRouter {
               final periodo = state.uri.queryParameters['periodo'] ?? _currentPeriodo();
               final accountId = state.uri.queryParameters['accountId'] ?? '';
               return CuentaDetallePage(cuentaId: id, accountId: accountId, periodo: periodo);
+            },
+          ),
+
+          // Cuentas - agregar
+          GoRoute(
+            path: '/cuentas/agregar/:periodo',
+            name: 'cuenta-agregar',
+            builder: (context, state) {
+              final periodo = state.pathParameters['periodo']!;
+              return AgregarCuentaPage(periodo: periodo);
             },
           ),
 

--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -114,6 +114,41 @@ class CuentaDatasource {
     return billing['is_paid'] != true && (billing['amount_paid'] ?? 0) == 0;
   }
 
+  /// POST /accounts/{accountId}/billings — crea un billing individual para una cuenta
+  Future<Cuenta> agregarCuentaIndividual({
+    required String accountId,
+    required double monto,
+    double montoPagado = 0,
+    String? periodo,
+    String? nombre,
+  }) async {
+    _sanitizarId(accountId);
+
+    if (monto < 0) {
+      throw ArgumentError('El monto no puede ser negativo');
+    }
+
+    final body = <String, dynamic>{
+      'amount_billed': monto,
+      'amount_paid': montoPagado,
+    };
+    if (periodo != null && periodo.isNotEmpty) {
+      body['period'] = periodo;
+    }
+    if (nombre != null && nombre.isNotEmpty) {
+      body['account_name'] = nombre;
+    }
+
+    final response = await _dio.post(
+      '${ApiConfig.baseUrl}/accounts/$accountId/billings',
+      data: body,
+    );
+
+    final data = response.data;
+    final billing = data['billing'] ?? data['data'] ?? data;
+    return _fromJson(billing);
+  }
+
   Cuenta _fromJson(Map<String, dynamic> json) {
     // La API puede devolver: is_paid (bool), status (string: 'paid', 'pending', 'overdue')
     final isPaid = json['is_paid'] as bool? ?? false;

--- a/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
+++ b/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
@@ -41,4 +41,21 @@ class CuentaRepositoryImpl implements CuentaRepository {
   ) {
     return _datasource.reopenAccount(cuentaId, accountId, montoOriginal);
   }
+
+  @override
+  Future<Cuenta> agregarCuentaIndividual({
+    required String accountId,
+    required double monto,
+    double montoPagado = 0,
+    String? periodo,
+    String? nombre,
+  }) {
+    return _datasource.agregarCuentaIndividual(
+      accountId: accountId,
+      monto: monto,
+      montoPagado: montoPagado,
+      periodo: periodo,
+      nombre: nombre,
+    );
+  }
 }

--- a/lib/features/cuentas/domain/repositories/cuenta_repository.dart
+++ b/lib/features/cuentas/domain/repositories/cuenta_repository.dart
@@ -19,4 +19,18 @@ abstract class CuentaRepository {
   /// [accountId] - ID de la cuenta
   /// [montoOriginal] - El monto facturado original (amount_billed) que se preserva
   Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal);
+
+  /// Agrega una cuenta individual (billing) para una cuenta específica
+  /// [accountId] - ID de la cuenta
+  /// [monto] - Monto facturado (amount_billed)
+  /// [montoPagado] - Monto pagado (default: 0)
+  /// [periodo] - Periodo opcional en formato YYYYMM (envía en body si se provee)
+  /// [nombre] - Nombre opcional de la cuenta
+  Future<Cuenta> agregarCuentaIndividual({
+    required String accountId,
+    required double monto,
+    double montoPagado = 0,
+    String? periodo,
+    String? nombre,
+  });
 }

--- a/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
+++ b/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
@@ -55,6 +55,25 @@ class CuentaReopenRequested extends CuentasEvent {
   List<Object?> get props => [cuentaId, accountId, montoOriginal];
 }
 
+class AgregarCuentaIndividualRequested extends CuentasEvent {
+  final String accountId;
+  final double monto;
+  final double montoPagado;
+  final String? periodo;
+  final String? nombre;
+
+  const AgregarCuentaIndividualRequested({
+    required this.accountId,
+    required this.monto,
+    this.montoPagado = 0,
+    this.periodo,
+    this.nombre,
+  });
+
+  @override
+  List<Object?> get props => [accountId, monto, montoPagado, periodo, nombre];
+}
+
 // States
 abstract class CuentasState extends Equatable {
   const CuentasState();
@@ -109,6 +128,13 @@ class ReopenFailure extends CuentasState {
   List<Object?> get props => [message];
 }
 
+class CuentaAgregadaFailure extends CuentasState {
+  final String message;
+  const CuentaAgregadaFailure(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
 class CuentasError extends CuentasState {
   final String message;
   const CuentasError(this.message);
@@ -125,6 +151,7 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     on<CuentaDetalleRequested>(_onDetalleRequested);
     on<PagoRegistrado>(_onPagoRegistrado);
     on<CuentaReopenRequested>(_onReopenRequested);
+    on<AgregarCuentaIndividualRequested>(_onAgregarCuentaIndividualRequested);
   }
 
   Future<void> _onLoadRequested(
@@ -205,5 +232,38 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     } catch (e) {
       emit(ReopenFailure(e.toString()));
     }
+  }
+
+  Future<void> _onAgregarCuentaIndividualRequested(
+    AgregarCuentaIndividualRequested event,
+    Emitter<CuentasState> emit,
+  ) async {
+    emit(CuentasLoading());
+    try {
+      await _repository.agregarCuentaIndividual(
+        accountId: event.accountId,
+        monto: event.monto,
+        montoPagado: event.montoPagado,
+        periodo: event.periodo,
+        nombre: event.nombre,
+      );
+      // Reload the cuentas list after adding
+      final currentState = state;
+      final periodo = event.periodo ?? _derivePeriodo(currentState);
+      if (periodo != null) {
+        final cuentas = await _repository.getCuentasPorPeriodo(periodo);
+        emit(CuentasLoaded(cuentas, periodo));
+      } else {
+        emit(CuentasLoaded([], ''));
+      }
+    } catch (e) {
+      emit(CuentaAgregadaFailure(e.toString()));
+    }
+  }
+
+  String? _derivePeriodo(CuentasState state) {
+    if (state is CuentasLoaded) return state.periodo;
+    if (state is CuentaDetalleLoaded) return state.cuenta.periodo;
+    return null;
   }
 }

--- a/lib/features/cuentas/presentation/pages/agregar_cuenta_page.dart
+++ b/lib/features/cuentas/presentation/pages/agregar_cuenta_page.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../bloc/cuentas_bloc.dart';
+
+/// Page for adding a new individual account/billing
+class AgregarCuentaPage extends StatefulWidget {
+  final String periodo;
+
+  const AgregarCuentaPage({super.key, required this.periodo});
+
+  @override
+  State<AgregarCuentaPage> createState() => _AgregarCuentaPageState();
+}
+
+class _AgregarCuentaPageState extends State<AgregarCuentaPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _accountIdController = TextEditingController();
+  final _montoTotalController = TextEditingController();
+  final _montoPagadoController = TextEditingController();
+  final _nombreController = TextEditingController();
+
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _accountIdController.dispose();
+    _montoTotalController.dispose();
+    _montoPagadoController.dispose();
+    _nombreController.dispose();
+    super.dispose();
+  }
+
+  String? _validateAccountId(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'El ID de cuenta es obligatorio';
+    }
+    if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(value)) {
+      return 'ID contiene caracteres inválidos';
+    }
+    return null;
+  }
+
+  String? _validateMonto(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'El monto es obligatorio';
+    }
+    final monto = double.tryParse(value);
+    if (monto == null) {
+      return 'Ingrese un número válido';
+    }
+    if (monto < 0) {
+      return 'El monto no puede ser negativo';
+    }
+    return null;
+  }
+
+  void _submitForm() {
+    if (_formKey.currentState!.validate()) {
+      final accountId = _accountIdController.text.trim();
+      final monto = double.parse(_montoTotalController.text.trim());
+      final montoPagado = _montoPagadoController.text.trim().isNotEmpty
+          ? double.parse(_montoPagadoController.text.trim())
+          : 0.0;
+      final nombre = _nombreController.text.trim();
+
+      setState(() => _isLoading = true);
+
+      context.read<CuentasBloc>().add(
+        AgregarCuentaIndividualRequested(
+          accountId: accountId,
+          monto: monto,
+          montoPagado: montoPagado,
+          periodo: widget.periodo,
+          nombre: nombre.isNotEmpty ? nombre : null,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Agregar Cuenta'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => context.pop(),
+        ),
+        backgroundColor: AppTheme.surfaceContainerLowest,
+      ),
+      backgroundColor: AppTheme.surfaceContainerLowest,
+      body: BlocConsumer<CuentasBloc, CuentasState>(
+        listener: (context, state) {
+          if (state is CuentasLoaded) {
+            // Account added successfully and list reloaded
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Cuenta agregada exitosamente'),
+                backgroundColor: Colors.green,
+              ),
+            );
+            context.pop();
+          } else if (state is CuentaAgregadaFailure) {
+            setState(() => _isLoading = false);
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Account ID field
+                    TextFormField(
+                      controller: _accountIdController,
+                      decoration: const InputDecoration(
+                        labelText: 'ID de Cuenta *',
+                        hintText: 'Ej: spotify-netflix',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.tag),
+                      ),
+                      textInputAction: TextInputAction.next,
+                      validator: _validateAccountId,
+                      enabled: !_isLoading,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Monto Total field
+                    TextFormField(
+                      controller: _montoTotalController,
+                      decoration: const InputDecoration(
+                        labelText: 'Monto Total *',
+                        hintText: 'Ej: 15000',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.attach_money),
+                      ),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'^\d+\.?\d{0,2}')),
+                      ],
+                      textInputAction: TextInputAction.next,
+                      validator: _validateMonto,
+                      enabled: !_isLoading,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Monto Pagado field (optional)
+                    TextFormField(
+                      controller: _montoPagadoController,
+                      decoration: const InputDecoration(
+                        labelText: 'Monto Pagado',
+                        hintText: 'Opcional - déjelo vacío si no ha pagado',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.payment),
+                      ),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'^\d+\.?\d{0,2}')),
+                      ],
+                      textInputAction: TextInputAction.next,
+                      validator: (value) {
+                        if (value != null && value.trim().isNotEmpty) {
+                          return _validateMonto(value);
+                        }
+                        return null;
+                      },
+                      enabled: !_isLoading,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Nombre field (optional)
+                    TextFormField(
+                      controller: _nombreController,
+                      decoration: const InputDecoration(
+                        labelText: 'Nombre de la Cuenta',
+                        hintText: 'Opcional - Ej: Netflix, Spotify',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.label_outline),
+                      ),
+                      textInputAction: TextInputAction.done,
+                      enabled: !_isLoading,
+                    ),
+                    const SizedBox(height: 8),
+
+                    // Periodo info
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        'Período: ${widget.periodo} (se usará el período actual)',
+                        style: TextStyle(
+                          color: AppTheme.outline,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Submit button
+                    SizedBox(
+                      height: 48,
+                      child: ElevatedButton(
+                        onPressed: _isLoading ? null : _submitForm,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppTheme.primarySeed,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: _isLoading
+                            ? const SizedBox(
+                                width: 24,
+                                height: 24,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                ),
+                              )
+                            : const Text(
+                                'Agregar Cuenta',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                      ),
+                    ),
+
+                    // Loading overlay
+                    if (_isLoading && state is CuentasLoading)
+                      Container(
+                        margin: const EdgeInsets.only(top: 16),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: AppTheme.surfaceContainerLow,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            SizedBox(width: 12),
+                            Text('Agregando cuenta...'),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
+++ b/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
@@ -67,6 +67,11 @@ class _ListaCuentasPageState extends State<ListaCuentasPage> {
       key: _scaffoldKey,
       drawer: _buildDrawer(context),
       backgroundColor: AppTheme.surfaceContainerLowest,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.push('/cuentas/agregar/$_currentPeriodo'),
+        backgroundColor: AppTheme.primarySeed,
+        child: const Icon(Icons.add, color: Colors.white),
+      ),
       body: SafeArea(
         child: CustomScrollView(
           slivers: [

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,34 +1,15 @@
 PODS:
-  - file_selector_macos (0.0.1):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
-  - webview_flutter_wkwebview (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-  - webview_flutter_wkwebview (from `Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 EXTERNAL SOURCES:
-  file_selector_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
-  webview_flutter_wkwebview:
-    :path: Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin
 
 SPEC CHECKSUMS:
-  file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
-  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		FBF847F91609F95594908E6F /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7372E25FB3D8A9E920693054 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +84,7 @@
 		39CBC7A35953CD23F6DD9123 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		49DACB8418B2F1DED729ADB0 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		7372E25FB3D8A9E920693054 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		91742DF8EA48EFC5703370A7 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				32D39435FE34E62CBB490096 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -164,6 +167,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -240,7 +244,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				171F2C087C2B007F76243AC5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -248,6 +251,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* movil_home_pay.app */;
 			productType = "com.apple.product-type.application";
@@ -292,6 +298,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -323,23 +332,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		171F2C087C2B007F76243AC5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -796,6 +788,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "movil_home_pay.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,10 +545,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -830,26 +830,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env
+    - .env.example

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env.example
+    - .env

--- a/test/features/cuentas/cuentas_bloc_test.dart
+++ b/test/features/cuentas/cuentas_bloc_test.dart
@@ -183,5 +183,64 @@ void main() {
         isA<ReopenFailure>(),
       ],
     );
+
+    group('AgregarCuentaIndividualRequested', () {
+      blocTest<CuentasBloc, CuentasState>(
+        'emits [CuentasLoading, CuentasLoaded] when add account succeeds and reloads cuentas',
+        setUp: () {
+          when(() => mockRepository.agregarCuentaIndividual(
+            periodo: any(named: 'periodo'),
+            accountId: any(named: 'accountId'),
+            monto: any(named: 'monto'),
+            nombre: any(named: 'nombre'),
+          )).thenAnswer((_) async => testCuenta);
+          when(() => mockRepository.getCuentasPorPeriodo(any()))
+              .thenAnswer((_) async => [testCuenta]);
+        },
+        build: () => CuentasBloc(mockRepository),
+        act: (bloc) => bloc.add(const AgregarCuentaIndividualRequested(
+          periodo: '202604',
+          accountId: 'acc-1',
+          monto: 15000,
+          nombre: 'Netflix',
+        )),
+        expect: () => [
+          isA<CuentasLoading>(),
+          isA<CuentasLoaded>(),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.agregarCuentaIndividual(
+            periodo: '202604',
+            accountId: 'acc-1',
+            monto: 15000,
+            nombre: 'Netflix',
+          )).called(1);
+          verify(() => mockRepository.getCuentasPorPeriodo('202604')).called(1);
+        },
+      );
+
+      blocTest<CuentasBloc, CuentasState>(
+        'emits [CuentasLoading, CuentaAgregadaFailure] when add account fails',
+        setUp: () {
+          when(() => mockRepository.agregarCuentaIndividual(
+            periodo: any(named: 'periodo'),
+            accountId: any(named: 'accountId'),
+            monto: any(named: 'monto'),
+            nombre: any(named: 'nombre'),
+          )).thenThrow(Exception('Account already exists'));
+        },
+        build: () => CuentasBloc(mockRepository),
+        act: (bloc) => bloc.add(const AgregarCuentaIndividualRequested(
+          periodo: '202604',
+          accountId: 'acc-1',
+          monto: 15000,
+          nombre: 'Netflix',
+        )),
+        expect: () => [
+          isA<CuentasLoading>(),
+          isA<CuentaAgregadaFailure>(),
+        ],
+      );
+    });
   });
 }

--- a/test/features/cuentas/data/datasources/agregar_cuenta_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/agregar_cuenta_datasource_test.dart
@@ -1,0 +1,280 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:movil_home_pay/core/config/api_config.dart';
+import 'package:movil_home_pay/features/cuentas/data/datasources/cuenta_datasource.dart';
+
+import '../../../../helpers/mock_dio.dart';
+import '../../../../helpers/test_bootstrap.dart';
+
+/// Builds a billing JSON map with API-shaped keys, as returned by the backend.
+Map<String, dynamic> billingJson({
+  String id = 'cta_new',
+  String accountId = 'acc_123',
+  String? accountName,
+  double amountBilled = 14990.0,
+  double amountPaid = 0.0,
+  bool isPaid = false,
+  String status = 'pending',
+  String period = '202404',
+}) {
+  return {
+    'id': id,
+    'account_id': accountId,
+    'account_name': ?accountName,
+    'amount_billed': amountBilled,
+    'amount_paid': amountPaid,
+    'is_paid': isPaid,
+    'status': status,
+    'period': period,
+  };
+}
+
+void main() {
+  late MockDio mockDio;
+  late CuentaDatasource datasource;
+
+  setUpAll(() {
+    bootstrapTests();
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  setUp(() {
+    mockDio = MockDio();
+    datasource = CuentaDatasource(mockDio);
+  });
+
+  void stubPost(Map<String, dynamic> responseData, {int statusCode = 201}) {
+    when(() => mockDio.post(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions:
+              RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings'),
+          statusCode: statusCode,
+          data: responseData,
+        ));
+  }
+
+  group('CuentaDatasource', () {
+    group('agregarCuentaIndividual', () {
+      test('POSTs to /accounts/{accountId}/billings with correct body', () async {
+        // Arrange
+        stubPost({'billing': billingJson(accountName: 'Netflix')});
+
+        // Act
+        final result = await datasource.agregarCuentaIndividual(
+          accountId: 'acc_123',
+          monto: 14990.0,
+          periodo: '202404',
+          nombre: 'Netflix',
+        );
+
+        // Assert
+        expect(result.id, equals('cta_new'));
+        expect(result.accountId, equals('acc_123'));
+        verify(() => mockDio.post(
+              '${ApiConfig.baseUrl}/accounts/acc_123/billings',
+              data: predicate<Map<String, dynamic>>((data) {
+                // account_id lives in the URL path, not in the body
+                expect(data.containsKey('account_id'), isFalse);
+                expect(data['amount_billed'], equals(14990.0));
+                expect(data['amount_paid'], equals(0));
+                expect(data['account_name'], equals('Netflix'));
+                expect(data['period'], equals('202404'));
+                return true;
+              }),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).called(1);
+      });
+
+      test('omits account_name when nombre is null', () async {
+        // Arrange
+        stubPost({
+          'billing': billingJson(id: 'cta_no_name', accountId: 'acc_456'),
+        });
+
+        // Act
+        final result = await datasource.agregarCuentaIndividual(
+          accountId: 'acc_456',
+          monto: 5000.0,
+        );
+
+        // Assert: nombre falls back to account_id when no account_name is returned
+        expect(result.nombre, equals('acc_456'));
+        verify(() => mockDio.post(
+              '${ApiConfig.baseUrl}/accounts/acc_456/billings',
+              data: predicate<Map<String, dynamic>>((data) {
+                expect(data.containsKey('account_name'), isFalse);
+                return true;
+              }),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).called(1);
+      });
+
+      test('omits period from body when periodo is null', () async {
+        // Arrange
+        stubPost({'billing': billingJson()});
+
+        // Act
+        await datasource.agregarCuentaIndividual(
+          accountId: 'acc_123',
+          monto: 9000.0,
+        );
+
+        // Assert
+        verify(() => mockDio.post(
+              any(),
+              data: predicate<Map<String, dynamic>>((data) {
+                expect(data.containsKey('period'), isFalse);
+                return true;
+              }),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).called(1);
+      });
+
+      test('throws ArgumentError for empty accountId', () async {
+        expect(
+          () => datasource.agregarCuentaIndividual(
+            accountId: '',
+            monto: 10000.0,
+          ),
+          throwsA(isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('vacío'),
+          )),
+        );
+      });
+
+      test('throws ArgumentError for whitespace-only accountId', () async {
+        expect(
+          () => datasource.agregarCuentaIndividual(
+            accountId: '   ',
+            monto: 10000.0,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for invalid accountId characters', () async {
+        expect(
+          () => datasource.agregarCuentaIndividual(
+            accountId: 'acc@invalid!',
+            monto: 10000.0,
+          ),
+          throwsA(isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('inválidos'),
+          )),
+        );
+      });
+
+      test('throws ArgumentError for negative monto', () async {
+        expect(
+          () => datasource.agregarCuentaIndividual(
+            accountId: 'acc_123',
+            monto: -100.0,
+          ),
+          throwsA(isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('negativo'),
+          )),
+        );
+      });
+
+      test('allows zero amount', () async {
+        // Arrange
+        stubPost({
+          'billing': billingJson(
+            id: 'cta_zero',
+            accountId: 'acc_zero',
+            amountBilled: 0.0,
+          ),
+        });
+
+        // Act & Assert - should not throw
+        final result = await datasource.agregarCuentaIndividual(
+          accountId: 'acc_zero',
+          monto: 0.0,
+        );
+        expect(result.monto, equals(0.0));
+      });
+
+      test('parses response correctly returning Cuenta with pendiente status', () async {
+        // Arrange
+        stubPost({
+          'billing': billingJson(
+            id: 'cta_created',
+            accountId: 'acc_789',
+            accountName: 'New Service',
+            amountBilled: 25000.0,
+            amountPaid: 0.0,
+            isPaid: false,
+            status: 'pending',
+            period: '202405',
+          ),
+        });
+
+        // Act
+        final result = await datasource.agregarCuentaIndividual(
+          accountId: 'acc_789',
+          monto: 25000.0,
+          nombre: 'New Service',
+        );
+
+        // Assert
+        expect(result.id, equals('cta_created'));
+        expect(result.estado, equals('pendiente'));
+        expect(result.isPaid, isFalse);
+        expect(result.montoPagado, equals(0.0));
+      });
+
+      test('throws DioException on 409 Conflict (duplicate account)', () async {
+        // Arrange
+        when(() => mockDio.post(
+              any(),
+              data: any(named: 'data'),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(
+              path: '${ApiConfig.baseUrl}/accounts/acc_duplicate/billings'),
+          type: DioExceptionType.badResponse,
+          message: 'Conflict',
+          response: Response(
+            requestOptions: RequestOptions(
+                path: '${ApiConfig.baseUrl}/accounts/acc_duplicate/billings'),
+            statusCode: 409,
+            data: {'error': 'Cuenta ya existe para este período'},
+          ),
+        ));
+
+        // Act & Assert
+        expect(
+          () => datasource.agregarCuentaIndividual(
+            accountId: 'acc_duplicate',
+            monto: 10000.0,
+          ),
+          throwsA(isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'statusCode',
+            equals(409),
+          )),
+        );
+      });
+    });
+  });
+}

--- a/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
+++ b/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
@@ -131,5 +131,105 @@ void main() {
         );
       });
     });
+
+    group('agregarCuentaIndividual', () {
+      test('delegates to datasource with correct parameters', () async {
+        final cuenta = CuentaFixture.createValidCuenta(
+          id: 'cta_new',
+          accountId: 'acc_123',
+          nombre: 'Netflix',
+          monto: 14990.0,
+          estado: 'pendiente',
+        );
+
+        when(() => mockDatasource.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenAnswer((_) async => cuenta);
+
+        final result = await repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 14990.0,
+          nombre: 'Netflix',
+        );
+
+        expect(result.id, equals('cta_new'));
+        expect(result.estado, equals('pendiente'));
+        verify(() => mockDatasource.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 14990.0,
+          nombre: 'Netflix',
+        )).called(1);
+      });
+
+      test('works without optional nombre', () async {
+        final cuenta = CuentaFixture.createValidCuenta(
+          id: 'cta_no_name',
+          accountId: 'acc_456',
+          nombre: 'acc_456',
+        );
+
+        when(() => mockDatasource.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenAnswer((_) async => cuenta);
+
+        final result = await repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_456',
+          monto: 5000.0,
+        );
+
+        expect(result.id, equals('cta_no_name'));
+        verify(() => mockDatasource.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_456',
+          monto: 5000.0,
+          nombre: null,
+        )).called(1);
+      });
+
+      test('forwards exceptions from datasource', () async {
+        when(() => mockDatasource.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenThrow(Exception('Network error'));
+
+        expect(
+          () => repository.agregarCuentaIndividual(
+            periodo: '202404',
+            accountId: 'acc_123',
+            monto: 10000.0,
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('forwards DioException on duplicate account', () async {
+        when(() => mockDatasource.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenThrow(Exception('Duplicate'));
+
+        expect(
+          () => repository.agregarCuentaIndividual(
+            periodo: '202404',
+            accountId: 'acc_duplicate',
+            monto: 10000.0,
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
   });
 }

--- a/test/features/cuentas/domain/repositories/cuenta_repository_test.dart
+++ b/test/features/cuentas/domain/repositories/cuenta_repository_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:movil_home_pay/features/cuentas/domain/entities/cuenta.dart';
+import 'package:movil_home_pay/features/cuentas/domain/repositories/cuenta_repository.dart';
+
+class MockCuentaRepository extends Mock implements CuentaRepository {}
+
+void main() {
+  group('CuentaRepository interface', () {
+    group('agregarCuentaIndividual', () {
+      test('should be declared as abstract method returning Future<Cuenta>', () {
+        // The interface contract: agregarCuentaIndividual must exist
+        // and return Future<Cuenta> with the specified parameters
+        final repository = MockCuentaRepository();
+
+        // Verify the method exists on the interface by stubbing it
+        when(() => repository.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenAnswer((_) async => Cuenta(
+          id: 'cta_new',
+          accountId: 'acc_123',
+          nombre: 'Test Account',
+          monto: 15000.0,
+          montoPagado: 0.0,
+          estado: 'pendiente',
+          periodo: '202404',
+        ));
+
+        // Act
+        final result = repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 15000.0,
+          nombre: 'Test Account',
+        );
+
+        // Assert
+        expect(result, isA<Future<Cuenta>>());
+        verify(() => repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 15000.0,
+          nombre: 'Test Account',
+        )).called(1);
+      });
+
+      test('accepts optional nombre parameter', () async {
+        final repository = MockCuentaRepository();
+
+        when(() => repository.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenAnswer((_) async => Cuenta(
+          id: 'cta_new',
+          accountId: 'acc_123',
+          nombre: 'Custom Name',
+          monto: 15000.0,
+          montoPagado: 0.0,
+          estado: 'pendiente',
+          periodo: '202404',
+        ));
+
+        // Act - call without nombre
+        final result = repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 15000.0,
+        );
+
+        // Assert
+        expect(await result, isA<Cuenta>());
+      });
+
+      test('returns Cuenta with pendiente status when account created', () async {
+        final repository = MockCuentaRepository();
+        final createdCuenta = Cuenta(
+          id: 'cta_new',
+          accountId: 'acc_123',
+          nombre: 'Test Account',
+          monto: 15000.0,
+          montoPagado: 0.0,
+          estado: 'pendiente',
+          periodo: '202404',
+        );
+
+        when(() => repository.agregarCuentaIndividual(
+          periodo: any(named: 'periodo'),
+          accountId: any(named: 'accountId'),
+          monto: any(named: 'monto'),
+          nombre: any(named: 'nombre'),
+        )).thenAnswer((_) async => createdCuenta);
+
+        final result = await repository.agregarCuentaIndividual(
+          periodo: '202404',
+          accountId: 'acc_123',
+          monto: 15000.0,
+        );
+
+        expect(result.estado, equals('pendiente'));
+        expect(result.id, isNotEmpty);
+      });
+    });
+  });
+}

--- a/test/features/cuentas/presentation/pages/agregar_cuenta_page_test.dart
+++ b/test/features/cuentas/presentation/pages/agregar_cuenta_page_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:movil_home_pay/features/cuentas/domain/entities/cuenta.dart';
+import 'package:movil_home_pay/features/cuentas/domain/repositories/cuenta_repository.dart';
+import 'package:movil_home_pay/features/cuentas/presentation/bloc/cuentas_bloc.dart';
+import 'package:movil_home_pay/features/cuentas/presentation/pages/agregar_cuenta_page.dart';
+
+class MockCuentaRepository extends Mock implements CuentaRepository {}
+
+class FakeCuentasEvent extends Fake implements CuentasEvent {}
+
+class FakeCuentasState extends Fake implements CuentasState {}
+
+void main() {
+  late MockCuentaRepository mockRepository;
+  late CuentasBloc cuentasBloc;
+
+  setUpAll(() {
+    registerFallbackValue(FakeCuentasEvent());
+    registerFallbackValue(FakeCuentasState());
+  });
+
+  setUp(() {
+    mockRepository = MockCuentaRepository();
+    cuentasBloc = CuentasBloc(mockRepository);
+  });
+
+  tearDown(() {
+    cuentasBloc.close();
+  });
+
+  final testCuenta = Cuenta(
+    id: '1',
+    accountId: 'spotify-test',
+    nombre: 'Spotify',
+    monto: 15000,
+    montoPagado: 0,
+    estado: 'pendiente',
+    periodo: '202605',
+  );
+
+  Widget buildTestWidget(CuentasBloc bloc, {String periodo = '202605'}) {
+    // Use a real GoRouter so the page's context.pop() on success works.
+    // The agregar page is a sub-route of '/', so the navigation stack has a
+    // parent page to pop back to.
+    final router = GoRouter(
+      initialLocation: '/agregar',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('home'))),
+          routes: [
+            GoRoute(
+              path: 'agregar',
+              builder: (context, state) => AgregarCuentaPage(periodo: periodo),
+            ),
+          ],
+        ),
+      ],
+    );
+    return BlocProvider<CuentasBloc>.value(
+      value: bloc,
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  group('AgregarCuentaPage Widget Tests', () {
+    testWidgets('renders all form fields', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Account ID field
+      expect(find.text('ID de Cuenta *'), findsOneWidget);
+      // Monto Total field
+      expect(find.text('Monto Total *'), findsOneWidget);
+      // Monto Pagado field
+      expect(find.text('Monto Pagado'), findsOneWidget);
+      // Nombre field
+      expect(find.text('Nombre de la Cuenta'), findsOneWidget);
+      // Submit button
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+
+    testWidgets('shows validation error for empty accountId', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Tap submit without filling form
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('El ID de cuenta es obligatorio'), findsOneWidget);
+    });
+
+    testWidgets('shows validation error for invalid accountId characters', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Enter invalid account ID in the first TextFormField (accountId)
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'invalid@id!');
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ID contiene caracteres inválidos'), findsOneWidget);
+    });
+
+    testWidgets('shows validation error for empty monto', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Fill only account ID
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'spotify-test');
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('El monto es obligatorio'), findsOneWidget);
+    });
+
+testWidgets('shows validation error for invalid monto', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Enter non-numeric text in monto field
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'spotify-test');
+
+      final montoField = find.byType(TextFormField).at(1);
+      // Input formatter should prevent non-numeric, but test validates anyway
+      await tester.enterText(montoField, '15.50'); // Valid number
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Form should submit with valid data
+      verify(() => mockRepository.agregarCuentaIndividual(
+        periodo: any(named: 'periodo'),
+        accountId: any(named: 'accountId'),
+        monto: any(named: 'monto'),
+        nombre: any(named: 'nombre'),
+      )).called(1);
+    });
+
+    testWidgets('submits form with valid data', (tester) async {
+      when(() => mockRepository.agregarCuentaIndividual(
+        periodo: any(named: 'periodo'),
+        accountId: any(named: 'accountId'),
+        monto: any(named: 'monto'),
+        nombre: any(named: 'nombre'),
+      )).thenAnswer((_) async => testCuenta);
+      when(() => mockRepository.getCuentasPorPeriodo(any()))
+          .thenAnswer((_) async => [testCuenta]);
+
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Fill form fields in order
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'spotify-test');
+
+      final montoField = find.byType(TextFormField).at(1);
+      await tester.enterText(montoField, '15000');
+
+      final nombreField = find.byType(TextFormField).at(3);
+      await tester.enterText(nombreField, 'Spotify');
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Should dispatch event
+      verify(() => mockRepository.agregarCuentaIndividual(
+        periodo: '202605',
+        accountId: 'spotify-test',
+        monto: 15000,
+        nombre: 'Spotify',
+      )).called(1);
+    });
+
+    testWidgets('shows loading state while submitting', (tester) async {
+      when(() => mockRepository.agregarCuentaIndividual(
+        periodo: any(named: 'periodo'),
+        accountId: any(named: 'accountId'),
+        monto: any(named: 'monto'),
+        nombre: any(named: 'nombre'),
+      )).thenAnswer((_) async {
+        await Future.delayed(const Duration(milliseconds: 100));
+        return testCuenta;
+      });
+      when(() => mockRepository.getCuentasPorPeriodo(any()))
+          .thenAnswer((_) async => [testCuenta]);
+
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Fill form
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'spotify-test');
+
+      final montoField = find.byType(TextFormField).at(1);
+      await tester.enterText(montoField, '15000');
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Button should be disabled (showing loading)
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('displays periodo info in form', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc, periodo: '202605'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Período: 202605 (se usará el período actual)'), findsOneWidget);
+    });
+
+    testWidgets('valid monto accepts decimal numbers', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      final accountIdField = find.byType(TextFormField).first;
+      await tester.enterText(accountIdField, 'spotify-test');
+
+      final montoField = find.byType(TextFormField).at(1);
+      await tester.enterText(montoField, '15.50');
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // No validation error - form dispatched event
+      verify(() => mockRepository.agregarCuentaIndividual(
+        periodo: any(named: 'periodo'),
+        accountId: any(named: 'accountId'),
+        monto: any(named: 'monto'),
+        nombre: any(named: 'nombre'),
+      )).called(1);
+    });
+
+    testWidgets('close button is present', (tester) async {
+      await tester.pumpWidget(buildTestWidget(cuentasBloc));
+      await tester.pumpAndSettle();
+
+      // Close button should be in AppBar
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #13

## Resumen
Agrega la posibilidad de crear billings individuales para una cuenta vía `POST /accounts/{id}/billings`, coherente con el resto de endpoints directos por cuenta. Implementa la issue #13 (agregar cuentas individuales al período actual).

### Cambios del feature
- `cuenta_datasource` / repositorio / bloc: soporte para `agregarCuentaIndividual`
- `AgregarCuentaPage`: formulario con validación de `accountId` y `monto`
- Nueva ruta `/cuentas/agregar/:periodo` y FAB en la lista de cuentas
- El período se pasa explícito desde la ruta al evento del bloc

### Tests
- Datasource: endpoint, body, validaciones y manejo de 409
- Repository y página (widget tests con GoRouter real)
- `flutter analyze`: sin issues · `flutter test`: 347 tests verdes

### Nota
Incluye además la migración de macOS a Swift Package Manager y bumps de `pubspec.lock`.