### PR TITLE
feat(cuentas): add bulk opening of accounts for a period

### DIFF
--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -28,7 +28,7 @@ class ApiConfig {
   static String companiesUrl({int page = 1, int pageSize = 20}) =>
       '$baseUrl$companiesPath?page=$page&page_size=$pageSize';
 
-  /// Direct billing endpoint: GET /accounts/{accountId}/billings/{billingId}
-  static String accountBillingUrl(String accountId, String billingId) =>
-      '$baseUrl/accounts/$accountId/billings/$billingId';
+  /// Direct billing endpoint: GET /billings/{billingId}
+  static String billingUrl(String billingId) =>
+      '$baseUrl$billingsPath/$billingId';
 }

--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -20,6 +20,10 @@ class ApiConfig {
   static String periodBillingsUrl(String period) =>
       '$baseUrl$periodsPath/$period$billingsPath';
 
+  /// Build URL para abrir todas las cuentas de un periodo (POST /periods/{period}/open)
+  static String periodOpenUrl(String period) =>
+      '$baseUrl$periodsPath/$period/open';
+
   /// Build URL para companies con pagination
   static String companiesUrl({int page = 1, int pageSize = 20}) =>
       '$baseUrl$companiesPath?page=$page&page_size=$pageSize';

--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -81,57 +81,60 @@ class CuentaDatasource {
         .toList();
   }
 
-  /// GET /accounts/{accountId}/billings/{billingId} — direct endpoint
-  Future<Cuenta> getDetalle(String accountId, String cuentaId) async {
-    _sanitizarId(accountId);
+  /// GET /billings/{billingId} — direct endpoint
+  Future<Cuenta> getDetalle(String cuentaId) async {
     _sanitizarId(cuentaId);
 
     final response = await _dio.get(
-      ApiConfig.accountBillingUrl(accountId, cuentaId),
+      ApiConfig.billingUrl(cuentaId),
     );
     final data = response.data;
     final billing = data['billing'] ?? data['data'] ?? data;
     return _fromJson(billing);
   }
 
-  /// PUT /accounts/{accountID}/billings/{id} — registra un pago
+  /// PUT /billings/{id} — registra un pago
   Future<bool> registrarPago(
     String cuentaId,
-    String accountId,
     double montoTotal,
     double montoPagado,
   ) async {
     _sanitizarId(cuentaId);
-    _sanitizarId(accountId);
 
     if (montoTotal < 0 || montoPagado < 0) {
       throw ArgumentError('Los montos no pueden ser negativos');
     }
 
+    final isPaid = montoPagado >= montoTotal;
     final response = await _dio.put(
-      '${ApiConfig.baseUrl}/accounts/$accountId/billings/$cuentaId',
-      data: {'amount_billed': montoTotal, 'amount_paid': montoPagado},
+      ApiConfig.billingUrl(cuentaId),
+      data: {
+        'amount_billed': montoTotal,
+        'amount_paid': montoPagado,
+        'is_paid': isPaid,
+        if (isPaid) 'paid_at': DateTime.now().toUtc().toIso8601String(),
+      },
     );
     final billing = response.data['billing'] ?? response.data;
     return billing['is_paid'] == true;
   }
 
-  /// PUT /accounts/{accountID}/billings/{id} — reabre una cuenta pagada
+  /// PUT /billings/{id} — reabre una cuenta pagada
   /// Resetea amount_paid a 0 y is_paid a false para marcar como no pagada
-  Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal) async {
+  Future<bool> reopenAccount(String cuentaId, double montoOriginal) async {
     _sanitizarId(cuentaId);
-    _sanitizarId(accountId);
 
     if (montoOriginal < 0) {
       throw ArgumentError('El monto no puede ser negativo');
     }
 
     final response = await _dio.put(
-      '${ApiConfig.baseUrl}/accounts/$accountId/billings/$cuentaId',
+      ApiConfig.billingUrl(cuentaId),
       data: {
         'amount_billed': montoOriginal,
         'amount_paid': 0,
         'is_paid': false,
+        'paid_at': null,
       },
     );
     final billing = response.data['billing'] ?? response.data;

--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -56,16 +56,29 @@ class CuentaDatasource {
     return items.map((json) => _fromJson(json)).toList();
   }
 
+  /// Extrae la lista de billings de una respuesta que puede venir envuelta
+  /// en distintos niveles: [...], {billings: [...]}, {data: {billings: [...]}}.
+  static List<dynamic> _extraerBillings(dynamic body) {
+    dynamic node = body;
+    // Desenvuelve hasta 3 niveles de Map buscando la lista bajo claves conocidas.
+    for (var i = 0; i < 3 && node is Map; i++) {
+      node = node['billings'] ?? node['data'] ?? node['items'] ?? node['results'];
+    }
+    if (node is List) return node;
+    if (node is Map<String, dynamic>) return [node]; // respuesta de un solo objeto
+    return const [];
+  }
+
   /// POST /periods/{period}/open — abre todas las cuentas del periodo
   Future<List<Cuenta>> abrirPeriodo(String periodo) async {
     _validarPeriodo(periodo);
 
     final response = await _dio.post(ApiConfig.periodOpenUrl(periodo));
 
-    final data = response.data;
-    final List<dynamic> items =
-        data['billings'] ?? data['data'] ?? data['items'] ?? [];
-    return items.map((json) => _fromJson(json)).toList();
+    final items = _extraerBillings(response.data);
+    return items
+        .map((json) => _fromJson(json as Map<String, dynamic>))
+        .toList();
   }
 
   /// GET /accounts/{accountId}/billings/{billingId} — direct endpoint

--- a/lib/features/cuentas/data/datasources/cuenta_datasource.dart
+++ b/lib/features/cuentas/data/datasources/cuenta_datasource.dart
@@ -56,6 +56,18 @@ class CuentaDatasource {
     return items.map((json) => _fromJson(json)).toList();
   }
 
+  /// POST /periods/{period}/open — abre todas las cuentas del periodo
+  Future<List<Cuenta>> abrirPeriodo(String periodo) async {
+    _validarPeriodo(periodo);
+
+    final response = await _dio.post(ApiConfig.periodOpenUrl(periodo));
+
+    final data = response.data;
+    final List<dynamic> items =
+        data['billings'] ?? data['data'] ?? data['items'] ?? [];
+    return items.map((json) => _fromJson(json)).toList();
+  }
+
   /// GET /accounts/{accountId}/billings/{billingId} — direct endpoint
   Future<Cuenta> getDetalle(String accountId, String cuentaId) async {
     _sanitizarId(accountId);

--- a/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
+++ b/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
@@ -14,20 +14,18 @@ class CuentaRepositoryImpl implements CuentaRepository {
   }
 
   @override
-  Future<Cuenta> getDetalleCuenta(String accountId, String cuentaId) {
-    return _datasource.getDetalle(accountId, cuentaId);
+  Future<Cuenta> getDetalleCuenta(String cuentaId) {
+    return _datasource.getDetalle(cuentaId);
   }
 
   @override
   Future<bool> registrarPago(
     String cuentaId,
-    String accountId,
     double montoTotal,
     double montoPagado,
   ) {
     return _datasource.registrarPago(
       cuentaId,
-      accountId,
       montoTotal,
       montoPagado,
     );
@@ -36,10 +34,9 @@ class CuentaRepositoryImpl implements CuentaRepository {
   @override
   Future<bool> reopenAccount(
     String cuentaId,
-    String accountId,
     double montoOriginal,
   ) {
-    return _datasource.reopenAccount(cuentaId, accountId, montoOriginal);
+    return _datasource.reopenAccount(cuentaId, montoOriginal);
   }
 
   @override

--- a/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
+++ b/lib/features/cuentas/data/repositories/cuenta_repository_impl.dart
@@ -43,6 +43,11 @@ class CuentaRepositoryImpl implements CuentaRepository {
   }
 
   @override
+  Future<List<Cuenta>> abrirPeriodo(String periodo) {
+    return _datasource.abrirPeriodo(periodo);
+  }
+
+  @override
   Future<Cuenta> agregarCuentaIndividual({
     required String accountId,
     required double monto,

--- a/lib/features/cuentas/domain/repositories/cuenta_repository.dart
+++ b/lib/features/cuentas/domain/repositories/cuenta_repository.dart
@@ -20,6 +20,11 @@ abstract class CuentaRepository {
   /// [montoOriginal] - El monto facturado original (amount_billed) que se preserva
   Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal);
 
+  /// Abre todas las cuentas (billings) de un periodo en una sola operación
+  /// [periodo] - Periodo en formato YYYYMM
+  /// Retorna la lista de cuentas abiertas
+  Future<List<Cuenta>> abrirPeriodo(String periodo);
+
   /// Agrega una cuenta individual (billing) para una cuenta específica
   /// [accountId] - ID de la cuenta
   /// [monto] - Monto facturado (amount_billed)

--- a/lib/features/cuentas/domain/repositories/cuenta_repository.dart
+++ b/lib/features/cuentas/domain/repositories/cuenta_repository.dart
@@ -5,20 +5,18 @@ abstract class CuentaRepository {
   /// Get list of accounts for a specific period (yyyymm format)
   Future<List<Cuenta>> getCuentasPorPeriodo(String periodo);
 
-  Future<Cuenta> getDetalleCuenta(String accountId, String cuentaId);
+  Future<Cuenta> getDetalleCuenta(String cuentaId);
 
   Future<bool> registrarPago(
     String cuentaId,
-    String accountId,
     double montoTotal,
     double montoPagado,
   );
 
   /// Reabre una cuenta pagada, reseteando el estado a no pagada
   /// [cuentaId] - ID del billing
-  /// [accountId] - ID de la cuenta
   /// [montoOriginal] - El monto facturado original (amount_billed) que se preserva
-  Future<bool> reopenAccount(String cuentaId, String accountId, double montoOriginal);
+  Future<bool> reopenAccount(String cuentaId, double montoOriginal);
 
   /// Abre todas las cuentas (billings) de un periodo en una sola operación
   /// [periodo] - Periodo en formato YYYYMM

--- a/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
+++ b/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
@@ -74,6 +74,13 @@ class AgregarCuentaIndividualRequested extends CuentasEvent {
   List<Object?> get props => [accountId, monto, montoPagado, periodo, nombre];
 }
 
+class AbrirPeriodoRequested extends CuentasEvent {
+  final String periodo;
+  const AbrirPeriodoRequested(this.periodo);
+  @override
+  List<Object?> get props => [periodo];
+}
+
 // States
 abstract class CuentasState extends Equatable {
   const CuentasState();
@@ -135,6 +142,20 @@ class CuentaAgregadaFailure extends CuentasState {
   List<Object?> get props => [message];
 }
 
+class AbrirPeriodoSuccess extends CuentasState {
+  final int cantidad;
+  const AbrirPeriodoSuccess(this.cantidad);
+  @override
+  List<Object?> get props => [cantidad];
+}
+
+class AbrirPeriodoFailure extends CuentasState {
+  final String message;
+  const AbrirPeriodoFailure(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
 class CuentasError extends CuentasState {
   final String message;
   const CuentasError(this.message);
@@ -152,6 +173,7 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     on<PagoRegistrado>(_onPagoRegistrado);
     on<CuentaReopenRequested>(_onReopenRequested);
     on<AgregarCuentaIndividualRequested>(_onAgregarCuentaIndividualRequested);
+    on<AbrirPeriodoRequested>(_onAbrirPeriodoRequested);
   }
 
   Future<void> _onLoadRequested(
@@ -258,6 +280,20 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
       }
     } catch (e) {
       emit(CuentaAgregadaFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onAbrirPeriodoRequested(
+    AbrirPeriodoRequested event,
+    Emitter<CuentasState> emit,
+  ) async {
+    emit(CuentasLoading());
+    try {
+      final cuentas = await _repository.abrirPeriodo(event.periodo);
+      emit(AbrirPeriodoSuccess(cuentas.length));
+      emit(CuentasLoaded(cuentas, event.periodo));
+    } catch (e) {
+      emit(AbrirPeriodoFailure(e.toString()));
     }
   }
 

--- a/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
+++ b/lib/features/cuentas/presentation/bloc/cuentas_bloc.dart
@@ -195,30 +195,11 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
   ) async {
     emit(CuentasLoading());
     try {
-      final accountId = _deriveAccountId(event.cuentaId) ?? event.accountId;
-      final cuenta = await _repository.getDetalleCuenta(
-        accountId,
-        event.cuentaId,
-      );
+      final cuenta = await _repository.getDetalleCuenta(event.cuentaId);
       emit(CuentaDetalleLoaded(cuenta));
     } catch (e) {
       emit(CuentasError(e.toString()));
     }
-  }
-
-  String? _deriveAccountId(String cuentaId) {
-    final currentState = state;
-    if (currentState is CuentasLoaded) {
-      try {
-        final cuenta = currentState.cuentas.firstWhere(
-          (c) => c.id == cuentaId,
-        );
-        return cuenta.accountId;
-      } catch (_) {
-        return null;
-      }
-    }
-    return null;
   }
 
   Future<void> _onPagoRegistrado(
@@ -229,7 +210,6 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     try {
       await _repository.registrarPago(
         event.cuentaId,
-        event.accountId,
         event.montoTotal,
         event.montoPagado,
       );
@@ -247,7 +227,6 @@ class CuentasBloc extends Bloc<CuentasEvent, CuentasState> {
     try {
       await _repository.reopenAccount(
         event.cuentaId,
-        event.accountId,
         event.montoOriginal,
       );
       emit(ReopenSuccess(event.cuentaId));

--- a/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
+++ b/lib/features/cuentas/presentation/pages/lista_cuentas_page.dart
@@ -72,24 +72,27 @@ class _ListaCuentasPageState extends State<ListaCuentasPage> {
         backgroundColor: AppTheme.primarySeed,
         child: const Icon(Icons.add, color: Colors.white),
       ),
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            // Header
-            SliverToBoxAdapter(
-              child: _buildHeader(),
-            ),
-            // Monthly Summary Card
-            SliverToBoxAdapter(
-              child: _buildSummaryCard(),
-            ),
-            // Filters
-            SliverToBoxAdapter(
-              child: _buildFilters(),
-            ),
-            // Bills List
-            _buildBillsList(),
-          ],
+      body: BlocListener<CuentasBloc, CuentasState>(
+        listener: _onStateChanged,
+        child: SafeArea(
+          child: CustomScrollView(
+            slivers: [
+              // Header
+              SliverToBoxAdapter(
+                child: _buildHeader(),
+              ),
+              // Monthly Summary Card
+              SliverToBoxAdapter(
+                child: _buildSummaryCard(),
+              ),
+              // Filters
+              SliverToBoxAdapter(
+                child: _buildFilters(),
+              ),
+              // Bills List
+              _buildBillsList(),
+            ],
+          ),
         ),
       ),
     );
@@ -138,6 +141,12 @@ class _ListaCuentasPageState extends State<ListaCuentasPage> {
                 ),
           Row(
             children: [
+              IconButton(
+                onPressed: () => _showAbrirPeriodoDialog(),
+                icon: const Icon(Icons.playlist_add_check),
+                color: AppTheme.primarySeed,
+                tooltip: 'Abrir período',
+              ),
               IconButton(
                 onPressed: () => _showLogoutDialog(),
                 icon: const Icon(Icons.logout),
@@ -650,6 +659,53 @@ child: Column(
       return const Color(0xFFEF4444); // red
     }
     return AppTheme.primarySeed;
+  }
+
+  void _onStateChanged(BuildContext context, CuentasState state) {
+    if (state is AbrirPeriodoSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Período abierto: ${state.cantidad} cuentas'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } else if (state is AbrirPeriodoFailure) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(state.message),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  void _showAbrirPeriodoDialog() {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Abrir período'),
+        content: Text(
+          'Esto abrirá TODAS las cuentas del período '
+          '${_formatPeriodo(_currentPeriodo)}. Esta acción es masiva. '
+          '¿Deseas continuar?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              context
+                  .read<CuentasBloc>()
+                  .add(AbrirPeriodoRequested(_currentPeriodo));
+            },
+            child: const Text('Abrir'),
+          ),
+        ],
+      ),
+    );
   }
 
   void _showLogoutDialog() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env
+    - .env.example

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env.example
+    - .env

--- a/test/features/cuentas/cuentas_bloc_test.dart
+++ b/test/features/cuentas/cuentas_bloc_test.dart
@@ -65,7 +65,7 @@ void main() {
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, CuentaDetalleLoaded] when CuentaDetalleRequested succeeds',
       setUp: () {
-        when(() => mockRepository.getDetalleCuenta(any(), any()))
+        when(() => mockRepository.getDetalleCuenta(any()))
             .thenAnswer((_) async => testCuenta);
       },
       build: () => CuentasBloc(mockRepository),
@@ -76,14 +76,14 @@ void main() {
         isA<CuentaDetalleLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockRepository.getDetalleCuenta('acc-1', '1')).called(1);
+        verify(() => mockRepository.getDetalleCuenta('1')).called(1);
       },
     );
 
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, CuentasError] when CuentaDetalleRequested fails',
       setUp: () {
-        when(() => mockRepository.getDetalleCuenta(any(), any()))
+        when(() => mockRepository.getDetalleCuenta(any()))
             .thenThrow(Exception('Not found'));
       },
       build: () => CuentasBloc(mockRepository),
@@ -98,7 +98,7 @@ void main() {
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, PagoSuccess] when PagoRegistrado succeeds',
       setUp: () {
-        when(() => mockRepository.registrarPago(any(), any(), any(), any()))
+        when(() => mockRepository.registrarPago(any(), any(), any()))
             .thenAnswer((_) async => true);
       },
       build: () => CuentasBloc(mockRepository),
@@ -115,7 +115,6 @@ void main() {
       verify: (_) {
         verify(() => mockRepository.registrarPago(
               '1',
-              'acc-1',
               15000,
               15000,
             )).called(1);
@@ -125,7 +124,7 @@ void main() {
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, PagoFailure] when PagoRegistrado fails',
       setUp: () {
-        when(() => mockRepository.registrarPago(any(), any(), any(), any()))
+        when(() => mockRepository.registrarPago(any(), any(), any()))
             .thenThrow(Exception('Payment failed'));
       },
       build: () => CuentasBloc(mockRepository),
@@ -144,7 +143,7 @@ void main() {
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, ReopenSuccess] when CuentaReopenRequested succeeds',
       setUp: () {
-        when(() => mockRepository.reopenAccount(any(), any(), any()))
+        when(() => mockRepository.reopenAccount(any(), any()))
             .thenAnswer((_) async => true);
       },
       build: () => CuentasBloc(mockRepository),
@@ -160,7 +159,6 @@ void main() {
       verify: (_) {
         verify(() => mockRepository.reopenAccount(
               '1',
-              'acc-1',
               15000,
             )).called(1);
       },
@@ -169,7 +167,7 @@ void main() {
     blocTest<CuentasBloc, CuentasState>(
       'emits [CuentasLoading, ReopenFailure] when CuentaReopenRequested fails',
       setUp: () {
-        when(() => mockRepository.reopenAccount(any(), any(), any()))
+        when(() => mockRepository.reopenAccount(any(), any()))
             .thenThrow(Exception('Reopen failed'));
       },
       build: () => CuentasBloc(mockRepository),

--- a/test/features/cuentas/cuentas_bloc_test.dart
+++ b/test/features/cuentas/cuentas_bloc_test.dart
@@ -242,5 +242,41 @@ void main() {
         ],
       );
     });
+
+    group('AbrirPeriodoRequested', () {
+      blocTest<CuentasBloc, CuentasState>(
+        'emits [CuentasLoading, AbrirPeriodoSuccess, CuentasLoaded] when open period succeeds',
+        setUp: () {
+          when(() => mockRepository.abrirPeriodo(any()))
+              .thenAnswer((_) async => [testCuenta, testCuenta]);
+        },
+        build: () => CuentasBloc(mockRepository),
+        act: (bloc) => bloc.add(const AbrirPeriodoRequested('202604')),
+        expect: () => [
+          isA<CuentasLoading>(),
+          isA<AbrirPeriodoSuccess>()
+              .having((s) => s.cantidad, 'cantidad', 2),
+          isA<CuentasLoaded>()
+              .having((s) => s.periodo, 'periodo', '202604'),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.abrirPeriodo('202604')).called(1);
+        },
+      );
+
+      blocTest<CuentasBloc, CuentasState>(
+        'emits [CuentasLoading, AbrirPeriodoFailure] when open period fails',
+        setUp: () {
+          when(() => mockRepository.abrirPeriodo(any()))
+              .thenThrow(Exception('Server error'));
+        },
+        build: () => CuentasBloc(mockRepository),
+        act: (bloc) => bloc.add(const AbrirPeriodoRequested('202604')),
+        expect: () => [
+          isA<CuentasLoading>(),
+          isA<AbrirPeriodoFailure>(),
+        ],
+      );
+    });
   });
 }

--- a/test/features/cuentas/data/datasources/abrir_periodo_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/abrir_periodo_datasource_test.dart
@@ -100,6 +100,25 @@ void main() {
         expect(result.first.id, equals('cta_only'));
       });
 
+      test('parses billings nested under a data envelope', () async {
+        // Arrange: backend wraps the list as { data: { billings: [...] } }
+        stubPost({
+          'data': {
+            'billings': [
+              billingJson(id: 'cta_nested_1'),
+              billingJson(id: 'cta_nested_2'),
+            ],
+          },
+        });
+
+        // Act
+        final result = await datasource.abrirPeriodo('202404');
+
+        // Assert
+        expect(result, hasLength(2));
+        expect(result.first.id, equals('cta_nested_1'));
+      });
+
       test('returns empty list when no billings are returned', () async {
         // Arrange
         stubPost({'billings': []});

--- a/test/features/cuentas/data/datasources/abrir_periodo_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/abrir_periodo_datasource_test.dart
@@ -1,0 +1,174 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:movil_home_pay/core/config/api_config.dart';
+import 'package:movil_home_pay/features/cuentas/data/datasources/cuenta_datasource.dart';
+
+import '../../../../helpers/mock_dio.dart';
+import '../../../../helpers/test_bootstrap.dart';
+
+/// Builds a billing JSON map with API-shaped keys, as returned by the backend.
+Map<String, dynamic> billingJson({
+  String id = 'cta_1',
+  String accountId = 'acc_1',
+  String? accountName,
+  double amountBilled = 10000.0,
+  double amountPaid = 0.0,
+  bool isPaid = false,
+  String status = 'pending',
+  String period = '202404',
+}) {
+  return {
+    'id': id,
+    'account_id': accountId,
+    'account_name': ?accountName,
+    'amount_billed': amountBilled,
+    'amount_paid': amountPaid,
+    'is_paid': isPaid,
+    'status': status,
+    'period': period,
+  };
+}
+
+void main() {
+  late MockDio mockDio;
+  late CuentaDatasource datasource;
+
+  setUpAll(() {
+    bootstrapTests();
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  setUp(() {
+    mockDio = MockDio();
+    datasource = CuentaDatasource(mockDio);
+  });
+
+  void stubPost(Map<String, dynamic> responseData, {int statusCode = 200}) {
+    when(() => mockDio.post(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions:
+              RequestOptions(path: ApiConfig.periodOpenUrl('202404')),
+          statusCode: statusCode,
+          data: responseData,
+        ));
+  }
+
+  group('CuentaDatasource', () {
+    group('abrirPeriodo', () {
+      test('POSTs to /periods/{period}/open and parses billings list', () async {
+        // Arrange
+        stubPost({
+          'billings': [
+            billingJson(id: 'cta_1', accountId: 'acc_1'),
+            billingJson(id: 'cta_2', accountId: 'acc_2'),
+          ],
+        });
+
+        // Act
+        final result = await datasource.abrirPeriodo('202404');
+
+        // Assert
+        expect(result, hasLength(2));
+        expect(result.first.id, equals('cta_1'));
+        expect(result.last.id, equals('cta_2'));
+        verify(() => mockDio.post(
+              ApiConfig.periodOpenUrl('202404'),
+              data: any(named: 'data'),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).called(1);
+      });
+
+      test('falls back to data key when billings key is absent', () async {
+        // Arrange
+        stubPost({
+          'data': [billingJson(id: 'cta_only')],
+        });
+
+        // Act
+        final result = await datasource.abrirPeriodo('202404');
+
+        // Assert
+        expect(result, hasLength(1));
+        expect(result.first.id, equals('cta_only'));
+      });
+
+      test('returns empty list when no billings are returned', () async {
+        // Arrange
+        stubPost({'billings': []});
+
+        // Act
+        final result = await datasource.abrirPeriodo('202404');
+
+        // Assert
+        expect(result, isEmpty);
+      });
+
+      test('throws ArgumentError for period with wrong length', () async {
+        expect(
+          () => datasource.abrirPeriodo('2024'),
+          throwsA(isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('YYYYMM'),
+          )),
+        );
+      });
+
+      test('throws ArgumentError for non-numeric period', () async {
+        expect(
+          () => datasource.abrirPeriodo('abcd12'),
+          throwsA(isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('dígitos'),
+          )),
+        );
+      });
+
+      test('throws ArgumentError for invalid month', () async {
+        expect(
+          () => datasource.abrirPeriodo('202413'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('propagates DioException on server error', () async {
+        // Arrange
+        when(() => mockDio.post(
+              any(),
+              data: any(named: 'data'),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(path: ApiConfig.periodOpenUrl('202404')),
+          type: DioExceptionType.badResponse,
+          response: Response(
+            requestOptions:
+                RequestOptions(path: ApiConfig.periodOpenUrl('202404')),
+            statusCode: 500,
+            data: {'error': 'Internal error'},
+          ),
+        ));
+
+        // Act & Assert
+        expect(
+          () => datasource.abrirPeriodo('202404'),
+          throwsA(isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'statusCode',
+            equals(500),
+          )),
+        );
+      });
+    });
+  });
+}

--- a/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
+++ b/test/features/cuentas/data/datasources/cuenta_datasource_test.dart
@@ -136,7 +136,7 @@ void main() {
     });
 
     group('getDetalle', () {
-      test('calls direct endpoint /accounts/{accountId}/billings/{billingId}', () async {
+      test('calls direct endpoint /billings/{billingId}', () async {
         final cuentaJson = {
           'id': 'cta_direct',
           'account_id': 'acc_123',
@@ -155,41 +155,33 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: ApiConfig.accountBillingUrl('acc_123', 'cta_direct')),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_direct')),
           statusCode: 200,
           data: responseData,
         ));
 
-        final result = await datasource.getDetalle('acc_123', 'cta_direct');
+        final result = await datasource.getDetalle('cta_direct');
 
         expect(result.id, equals('cta_direct'));
         expect(result.nombre, equals('Direct Service'));
-      });
-
-      test('throws ArgumentError for invalid accountId characters', () async {
-        expect(
-          () => datasource.getDetalle('acc@invalid!', 'cta_001'),
-          throwsA(isA<ArgumentError>()),
-        );
+        verify(() => mockDio.get(
+          ApiConfig.billingUrl('cta_direct'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).called(1);
       });
 
       test('throws ArgumentError for invalid cuentaId characters', () async {
         expect(
-          () => datasource.getDetalle('acc_123', 'cta@invalid!'),
-          throwsA(isA<ArgumentError>()),
-        );
-      });
-
-      test('throws ArgumentError for empty accountId', () async {
-        expect(
-          () => datasource.getDetalle('', 'cta_001'),
+          () => datasource.getDetalle('cta@invalid!'),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for empty cuentaId', () async {
         expect(
-          () => datasource.getDetalle('acc_123', ''),
+          () => datasource.getDetalle(''),
           throwsA(isA<ArgumentError>()),
         );
       });
@@ -208,19 +200,52 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
           statusCode: 200,
           data: responseData,
         ));
 
         final result = await datasource.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           15000.0,
         );
 
         expect(result, isTrue);
+      });
+
+      test('hits /billings/{id} with is_paid and paid_at when fully paid', () async {
+        final responseData = {
+          'billing': {'is_paid': true},
+        };
+
+        when(() => mockDio.put(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
+          statusCode: 200,
+          data: responseData,
+        ));
+
+        await datasource.registrarPago('cta_001', 15000.0, 15000.0);
+
+        verify(() => mockDio.put(
+          ApiConfig.billingUrl('cta_001'),
+          data: predicate<Map<String, dynamic>>((data) {
+            expect(data['amount_billed'], equals(15000.0));
+            expect(data['amount_paid'], equals(15000.0));
+            expect(data['is_paid'], equals(true));
+            expect(data['paid_at'], isA<String>());
+            return true;
+          }),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).called(1);
       });
 
       test('returns false when is_paid is false', () async {
@@ -235,14 +260,13 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
           statusCode: 200,
           data: responseData,
         ));
 
         final result = await datasource.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           10000.0,
         );
@@ -250,30 +274,62 @@ void main() {
         expect(result, isFalse);
       });
 
+      test('omits paid_at when payment is partial', () async {
+        final responseData = {
+          'billing': {'is_paid': false},
+        };
+
+        when(() => mockDio.put(
+          any(),
+          data: any(named: 'data'),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
+          statusCode: 200,
+          data: responseData,
+        ));
+
+        await datasource.registrarPago('cta_001', 15000.0, 10000.0);
+
+        verify(() => mockDio.put(
+          ApiConfig.billingUrl('cta_001'),
+          data: predicate<Map<String, dynamic>>((data) {
+            expect(data['is_paid'], equals(false));
+            expect(data.containsKey('paid_at'), isFalse);
+            return true;
+          }),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        )).called(1);
+      });
+
       test('throws ArgumentError for negative montoTotal', () async {
         expect(
-          () => datasource.registrarPago('cta_001', 'acc_123', -100.0, 0.0),
+          () => datasource.registrarPago('cta_001', -100.0, 0.0),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for negative montoPagado', () async {
         expect(
-          () => datasource.registrarPago('cta_001', 'acc_123', 100.0, -50.0),
+          () => datasource.registrarPago('cta_001', 100.0, -50.0),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for empty cuentaId', () async {
         expect(
-          () => datasource.registrarPago('', 'acc_123', 100.0, 100.0),
+          () => datasource.registrarPago('', 100.0, 100.0),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for invalid cuentaId characters', () async {
         expect(
-          () => datasource.registrarPago('cta@invalid!', 'acc_123', 100.0, 100.0),
+          () => datasource.registrarPago('cta@invalid!', 100.0, 100.0),
           throwsA(isA<ArgumentError>()),
         );
       });
@@ -292,21 +348,20 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
           statusCode: 200,
           data: responseData,
         ));
 
         final result = await datasource.reopenAccount(
           'cta_001',
-          'acc_123',
           15000.0,
         );
 
         expect(result, isTrue);
       });
 
-      test('sends correct payload with amount_billed, amount_paid=0, is_paid=false', () async {
+      test('sends correct payload with amount_billed, amount_paid=0, is_paid=false, paid_at=null', () async {
         final responseData = {
           'billing': {'is_paid': false, 'amount_paid': 0},
         };
@@ -318,19 +373,20 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
           statusCode: 200,
           data: responseData,
         ));
 
-        await datasource.reopenAccount('cta_001', 'acc_123', 15000.0);
+        await datasource.reopenAccount('cta_001', 15000.0);
 
         verify(() => mockDio.put(
-          any(),
+          ApiConfig.billingUrl('cta_001'),
           data: predicate<Map<String, dynamic>>((data) {
             expect(data['amount_billed'], equals(15000.0));
             expect(data['amount_paid'], equals(0));
             expect(data['is_paid'], equals(false));
+            expect(data['paid_at'], isNull);
             return true;
           }),
           queryParameters: any(named: 'queryParameters'),
@@ -351,14 +407,13 @@ void main() {
           options: any(named: 'options'),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((_) async => Response(
-          requestOptions: RequestOptions(path: '${ApiConfig.baseUrl}/accounts/acc_123/billings/cta_001'),
+          requestOptions: RequestOptions(path: ApiConfig.billingUrl('cta_001')),
           statusCode: 200,
           data: responseData,
         ));
 
         final result = await datasource.reopenAccount(
           'cta_001',
-          'acc_123',
           15000.0,
         );
 
@@ -367,21 +422,21 @@ void main() {
 
       test('throws ArgumentError for negative montoOriginal', () async {
         expect(
-          () => datasource.reopenAccount('cta_001', 'acc_123', -100.0),
+          () => datasource.reopenAccount('cta_001', -100.0),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for empty cuentaId', () async {
         expect(
-          () => datasource.reopenAccount('', 'acc_123', 15000.0),
+          () => datasource.reopenAccount('', 15000.0),
           throwsA(isA<ArgumentError>()),
         );
       });
 
       test('throws ArgumentError for invalid cuentaId characters', () async {
         expect(
-          () => datasource.reopenAccount('cta@invalid!', 'acc_123', 15000.0),
+          () => datasource.reopenAccount('cta@invalid!', 15000.0),
           throwsA(isA<ArgumentError>()),
         );
       });

--- a/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
+++ b/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
@@ -231,5 +231,32 @@ void main() {
         );
       });
     });
+
+    group('abrirPeriodo', () {
+      test('delegates to datasource and returns opened cuentas', () async {
+        final cuentas = [
+          CuentaFixture.createValidCuenta(id: 'cta_1'),
+          CuentaFixture.createValidCuenta(id: 'cta_2'),
+        ];
+
+        when(() => mockDatasource.abrirPeriodo('202404'))
+            .thenAnswer((_) async => cuentas);
+
+        final result = await repository.abrirPeriodo('202404');
+
+        expect(result, hasLength(2));
+        verify(() => mockDatasource.abrirPeriodo('202404')).called(1);
+      });
+
+      test('forwards exceptions from datasource', () async {
+        when(() => mockDatasource.abrirPeriodo(any()))
+            .thenThrow(Exception('Server error'));
+
+        expect(
+          () => repository.abrirPeriodo('202404'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
   });
 }

--- a/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
+++ b/test/features/cuentas/data/repositories/cuenta_repository_impl_test.dart
@@ -55,24 +55,24 @@ void main() {
     });
 
     group('getDetalleCuenta', () {
-      test('delegates to datasource with correct accountId and cuentaId', () async {
+      test('delegates to datasource with correct cuentaId', () async {
         final cuenta = CuentaFixture.createValidCuenta(id: 'cta_detail');
 
-        when(() => mockDatasource.getDetalle('acc_123', 'cta_detail'))
+        when(() => mockDatasource.getDetalle('cta_detail'))
             .thenAnswer((_) async => cuenta);
 
-        final result = await repository.getDetalleCuenta('acc_123', 'cta_detail');
+        final result = await repository.getDetalleCuenta('cta_detail');
 
         expect(result.id, equals('cta_detail'));
-        verify(() => mockDatasource.getDetalle('acc_123', 'cta_detail')).called(1);
+        verify(() => mockDatasource.getDetalle('cta_detail')).called(1);
       });
 
       test('forwards exceptions from datasource', () async {
-        when(() => mockDatasource.getDetalle(any(), any()))
+        when(() => mockDatasource.getDetalle(any()))
             .thenThrow(Exception('Not found'));
 
         expect(
-          () => repository.getDetalleCuenta('acc_123', 'cta_invalid'),
+          () => repository.getDetalleCuenta('cta_invalid'),
           throwsA(isA<Exception>()),
         );
       });
@@ -82,14 +82,12 @@ void main() {
       test('delegates to datasource with correct parameters', () async {
         when(() => mockDatasource.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           15000.0,
         )).thenAnswer((_) async => true);
 
         final result = await repository.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           15000.0,
         );
@@ -97,7 +95,6 @@ void main() {
         expect(result, isTrue);
         verify(() => mockDatasource.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           15000.0,
         )).called(1);
@@ -106,14 +103,12 @@ void main() {
       test('returns false when payment not successful', () async {
         when(() => mockDatasource.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           5000.0,
         )).thenAnswer((_) async => false);
 
         final result = await repository.registrarPago(
           'cta_001',
-          'acc_123',
           15000.0,
           5000.0,
         );
@@ -122,11 +117,11 @@ void main() {
       });
 
       test('forwards exceptions from datasource', () async {
-        when(() => mockDatasource.registrarPago(any(), any(), any(), any()))
+        when(() => mockDatasource.registrarPago(any(), any(), any()))
             .thenThrow(Exception('Payment failed'));
 
         expect(
-          () => repository.registrarPago('cta_001', 'acc_123', 15000.0, 15000.0),
+          () => repository.registrarPago('cta_001', 15000.0, 15000.0),
           throwsA(isA<Exception>()),
         );
       });


### PR DESCRIPTION
Closes #14

## Resumen
Implementa la apertura masiva de todas las cuentas de un período vía `POST /periods/{period}/open`, siguiendo el patrón de clean architecture existente.

### Cambios por capa
- **Config:** `ApiConfig.periodOpenUrl(period)`
- **Datasource:** `abrirPeriodo(periodo)` con validación de período `YYYYMM` y parseo de la lista de billings
- **Repository:** método en la interfaz de dominio + delegación en la implementación
- **Bloc:** evento `AbrirPeriodoRequested` con estados `AbrirPeriodoSuccess(cantidad)` / `AbrirPeriodoFailure`; recarga la lista con la respuesta sin segunda llamada
- **UI:** botón "Abrir período" en el header, **diálogo de confirmación** (acción masiva) y feedback con SnackBar; el loading reutiliza el indicador existente

### Tests
- Datasource: endpoint, parseo, fallbacks de keys, validaciones y error 500
- Repository: delegación y propagación de errores
- Bloc: secuencia de estados en éxito y fallo
- `flutter analyze`: sin issues · `flutter test`: **358 tests** verdes