### PR TITLE
ci: add GitHub issue templates for Home Pay (#24)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,131 @@
+name: Reporte de bug
+description: Reportá un bug en Home Pay
+labels: ["🐛 bug", "🔍 status:needs-review"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Cómo funciona
+
+        1. **Enviá** este reporte de bug → recibirá automáticamente la etiqueta `🔍 status:needs-review`
+        2. Una persona mantenedora lo revisará y agregará `status:approved` (o lo cerrará como inválido/duplicado)
+        3. **Recién entonces** deberías abrir un PR para corregirlo
+
+        Los PRs que corrijan issues sin `status:approved` serán rechazados automáticamente.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Checklist previa
+      options:
+        - label: Busqué en los issues existentes y esto no es un duplicado
+          required: true
+        - label: Entiendo que los PRs serán rechazados si el issue vinculado no tiene `status:approved`
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Descripción del bug
+      description: Una descripción clara y concisa del bug.
+      placeholder: Describí el bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 🔄 Pasos para reproducir
+      description: Pasos necesarios para reproducir el comportamiento.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: ✅ Comportamiento esperado
+      description: ¿Qué esperabas que ocurriera?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: ❌ Comportamiento actual
+      description: ¿Qué ocurrió realmente?
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## 🖥️ Entorno
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 📋 Área afectada
+      description: ¿En qué parte de la app ocurre el bug?
+      options:
+        - Autenticación / sesión
+        - Pago Mensual (cuentas / billings)
+        - Empresas
+        - Administración
+        - Navegación / UI general
+        - No estoy seguro
+        - Otro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Plataforma
+      options:
+        - Android
+        - iOS
+        - Web
+        - Otra
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: Versión de la app
+      description: La versión instalada (ver `version` en pubspec.yaml o la pantalla de ajustes).
+      placeholder: "ej. 1.0.0+1"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Dispositivo y versión del SO
+      description: Modelo del dispositivo y versión de Android/iOS.
+      placeholder: "ej. Pixel 7 — Android 14 / iPhone 13 — iOS 17.2"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 💡 Logs / salida de error
+      description: Pegá cualquier log relevante. Se formateará automáticamente como código.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+      description: Agregá cualquier otro contexto sobre el problema (capturas, datos de configuración, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Preguntas y discusiones
+    url: https://github.com/fvalenzuela-dev/movil_home_pay/discussions
+    about: Usá las discusiones para preguntas, no los issues

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Solicitud de funcionalidad
+description: Proponé una nueva funcionalidad o mejora para Home Pay
+labels: ["✨ enhancement", "🔍 status:needs-review"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Cómo funciona
+
+        1. **Enviá** esta solicitud de feature → recibirá automáticamente la etiqueta `🔍 status:needs-review`
+        2. Una persona mantenedora la revisará y agregará `status:approved` (o la cerrará como fuera de alcance/duplicada)
+        3. **Recién entonces** deberías abrir un PR para implementarla
+
+        Los PRs que implementen features sin `status:approved` en el issue vinculado serán rechazados automáticamente.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Checklist previa
+      options:
+        - label: Busqué en los issues existentes y esto no es un duplicado
+          required: true
+        - label: Entiendo que los PRs serán rechazados si el issue vinculado no tiene `status:approved`
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 🔍 Área afectada
+      description: ¿Qué parte de la app afectaría esta funcionalidad?
+      options:
+        - Autenticación / sesión
+        - Pago Mensual (cuentas / billings)
+        - Empresas
+        - Administración
+        - Navegación / UI general
+        - Configuración / proyecto
+        - Otro
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 💡 Problema
+      description: ¿Tu solicitud está relacionada con un problema? Describilo con claridad.
+      placeholder: |
+        Me frustra cuando...
+        Actualmente no es posible...
+        Cada vez que necesito hacer X, tengo que hacerlo manualmente...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 📦 Solución propuesta
+      description: Describí la solución que te gustaría. Sé lo más específico posible.
+      placeholder: |
+        Como usuario quiero...
+        En la pantalla X debería poder...
+        Comportamiento esperado:
+          ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🔄 Alternativas consideradas
+      description: Describí otras soluciones o features que hayas considerado.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 📎 Contexto adicional
+      description: Agregá cualquier otro contexto, capturas o ejemplos sobre esta solicitud.
+    validations:
+      required: false


### PR DESCRIPTION
## Resumen

Agrega templates de issues de GitHub adaptados a Home Pay (app Flutter), reemplazando los borradores que venían copiados de otro proyecto (un CLI).

Closes #24

## Cambios

- **`bug_report.yml`**: labels reales (`🐛 bug`, `🔍 status:needs-review`), áreas reales de la app (Autenticación, Pago Mensual, Empresas, Administración, Navegación/UI) y campos de entorno móvil (plataforma, versión de la app, dispositivo + SO). Se quitó lo del CLI (`gga version`, dropdown de "Agente / cliente de IA").
- **`feature_request.yml`**: labels reales (`✨ enhancement`, `🔍 status:needs-review`), áreas reales y placeholders en formato historia de usuario.
- **`config.yml`**: `blank_issues_enabled: false` y enlace a Discussions del repo correcto (Discussions quedó habilitado).

## Notas

- Los labels referenciados coinciden exactamente con los nombres reales del repo (incluido el emoji); de lo contrario GitHub no los aplica.
- Discussions fue habilitado en el repo para que el enlace de `config.yml` funcione.
